### PR TITLE
Update Git repo and issue tracker URLs to GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,14 @@ more.
 
 The project maintains the following source code repositories
 
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap.tools
+* https://github.com/eclipse-rap/org.eclipse.rap
+* https://github.com/eclipse-rap/org.eclipse.rap.tools
 
-This project uses Bugzilla to track ongoing development and issues.
+This project uses GitHub to track ongoing development and issues.
 
-* Search for issues: https://bugs.eclipse.org/bugs/buglist.cgi?product=RAP
-* Create a new report: https://bugs.eclipse.org/bugs/enter_bug.cgi?product=RAP
+* Search for issues: https://github.com/eclipse-rap/org.eclipse.rap/issues
+* Create a new report: https://github.com/eclipse-rap/org.eclipse.rap/issues/new/choose
+* For old issues until 2022-04, see Bugzilla at https://bugs.eclipse.org/bugs/buglist.cgi?product=RAP
 
 Be sure to search for existing bugs before you create another one. Remember that
 contributions are always welcome!

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -28,8 +28,8 @@ SPDX-License-Identifier: EPL-1.0
 
 The project maintains the following source code repositories:
 
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap
-* https://git.eclipse.org/r/plugins/gitiles/rap/org.eclipse.rap.tools
+* https://github.com/eclipse-rap/org.eclipse.rap
+* https://github.com/eclipse-rap/org.eclipse.rap.tools
 
 ## Third-party Content
 

--- a/README.md
+++ b/README.md
@@ -86,5 +86,5 @@ welcome!
 [7]: http://wiki.eclipse.org/EPL
 [8]: http://www.eclipse.org/forums/eclipse.technology.rap
 [9]: https://dev.eclipse.org/mailman/listinfo/rap-dev
-[10]: https://bugs.eclipse.org/bugs/buglist.cgi?product=RAP
-[11]: https://bugs.eclipse.org/bugs/enter_bug.cgi?product=RAP
+[10]: https://github.com/eclipse-rap/org.eclipse.rap/issues
+[11]: https://github.com/eclipse-rap/org.eclipse.rap/issues/new/choose

--- a/releng/org.eclipse.rap.build/pom.xml
+++ b/releng/org.eclipse.rap.build/pom.xml
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
     <tycho.version>2.1.0</tycho.version>
-    <tycho.scmUrl>scm:git:https://git.eclipse.org/r/rap/org.eclipse.rap.git</tycho.scmUrl>
+    <tycho.scmUrl>scm:git:https://github.com/eclipse-rap/org.eclipse.rap</tycho.scmUrl>
     <!-- disabled due to bug 393977
     <tycho-baseline-repo.url>http://download.eclipse.org/rt/rap/3.2/</tycho-baseline-repo.url>
      -->


### PR DESCRIPTION
With the migration from Gerrit/cgit to GitHub, the SCM URL that is added
to all MANIFEST.MF files during build time needs to be changed. Update
this to reflect the migration.

Bug: https://github.com/eclipse-rap/org.eclipse.rap/issues/1
Signed-off-by: Markus Knauer <mknauer@eclipsesource.com>