### PR TITLE
Synchronise JUnit version

### DIFF
--- a/releng/org.eclipse.rap.build/pom.xml
+++ b/releng/org.eclipse.rap.build/pom.xml
@@ -289,7 +289,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Use the very same JUnit version 4.13.2 in the Tycho Maven dependencies
as the one provided by the Eclipse Orbit project. This also mitigates a
local information disclosure vulnerability in older JUnit libraries.