### PR TITLE
Update demo launch configs with missing OSGi bundles

### DIFF
--- a/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
+++ b/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
@@ -79,6 +79,11 @@
         <setEntry value="org.eclipse.rap.rwt.osgi@default:default"/>
         <setEntry value="org.eclipse.rap.rwt@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo.controls@default:default"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
@@ -78,6 +78,11 @@
         <setEntry value="org.eclipse.rap.ui.workbench@default:default"/>
         <setEntry value="org.eclipse.rap.ui@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo@default:default"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
@@ -78,6 +78,11 @@
         <setEntry value="org.eclipse.rap.ui.workbench@default:default"/>
         <setEntry value="org.eclipse.rap.ui@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo@default:default"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
@@ -62,6 +62,11 @@
         <setEntry value="org.eclipse.rap.ui.workbench@default:default"/>
         <setEntry value="org.eclipse.rap.ui@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo@default:default"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
@@ -78,6 +78,11 @@
         <setEntry value="org.eclipse.rap.ui.workbench@default:default"/>
         <setEntry value="org.eclipse.rap.ui@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo@default:default"/>

--- a/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
+++ b/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
@@ -81,6 +81,11 @@
         <setEntry value="org.eclipse.rap.rwt.osgi@default:default"/>
         <setEntry value="org.eclipse.rap.rwt@default:default"/>
         <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.osgi.util.function@default:default"/>
+        <setEntry value="org.osgi.util.measurement@default:default"/>
+        <setEntry value="org.osgi.util.position@default:default"/>
+        <setEntry value="org.osgi.util.promise@default:default"/>
+        <setEntry value="org.osgi.util.xml@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.examples.pages@default:default"/>


### PR DESCRIPTION
Now org.osgi.util.* bundles are needed for normal operation.