### PR TITLE
Add documentation how to use Grid cell selection with markup

### DIFF
--- a/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -1154,6 +1154,11 @@ public class Grid extends Composite {
 
   /**
    * Sets whether cells are selectable in the receiver.
+   * <p>
+   * Note: Using markup in the cell text will require <em>data-cell-index</em> attribute to be added
+   * to the HTML element that points to the cell column index. Row header column (visible or not)
+   * always has index 0.
+   * </p>
    *
    * @param cellSelection the cellSelection to set
    * @throws org.eclipse.swt.SWTException


### PR DESCRIPTION
Bug 571201: [RAP] [Grid] Selecting a cell is not possible when the
markup contains an img tag
https://bugs.eclipse.org/bugs/show_bug.cgi?id=571201