### PR TITLE
Include org.osgi.service.prefs bundle in RAP Equinox features

### DIFF
--- a/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
@@ -458,6 +458,20 @@
          unpack="false"/>
 
    <plugin
+         id="org.osgi.service.prefs"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.prefs.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.osgi.util.function"
          download-size="0"
          install-size="0"

--- a/features/org.eclipse.rap.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.equinox.target.feature/feature.xml
@@ -458,6 +458,20 @@
          unpack="false"/>
 
    <plugin
+         id="org.osgi.service.prefs"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.prefs.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.osgi.util.function"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The Java package provided by this package was formerly provided
internally by the bundle `org.eclipse.equinox.preferences` and has been
moved to a bundle of its own. In order to satisfy all downstream
dependencies include the OSGi bundle now in both RAP Equinox features.