### PR TITLE
Fix an issue with year picked from the calendar below 1970

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/widgets/DateTimeDate.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/widgets/DateTimeDate.js
@@ -800,7 +800,7 @@ rwt.qx.Class.define( "rwt.widgets.DateTimeDate", {
     _onCalendarDateChange : function() {
       if( !this._internalDateChanged ) {
         var milliseconds = this._calendar.getDate().getTime();
-        var min = this._minimum ? this._minimum.getTime() : Number.MIN_VALUE;
+        var min = this._minimum ? this._minimum.getTime() : - Number.MAX_VALUE;
         var max = this._maximum ? this._maximum.getTime() : Number.MAX_VALUE;
         if( milliseconds >= min && milliseconds <= max ) {
           this._setDate( this._calendar.getDate() );


### PR DESCRIPTION
For years below 01/01/1970 00:00:00 the time in milliseconds is
negative.

In JS the Number.MIN_VALUE "is NOT the most negative number", but the
"the smallest positive numeric value closed to zero".
Changing Number.MIN_VALUE to - Number.MAX_VALUE solves the problem.

Fix #29