### PR TITLE
Add support for MenuItem tooltip text

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/remote/handler/MenuItemHandler.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/remote/handler/MenuItemHandler.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 EclipseSource and others.
+ * Copyright (c) 2011, 2022 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,6 +49,8 @@ rwt.remote.HandlerRegistry.add( "rwt.widgets.MenuItem", {
     "text",
     "mnemonicIndex",
     "image",
+    "toolTipMarkupEnabled",
+    "toolTip",
     "selection",
     "customVariant",
     "data"
@@ -86,6 +88,8 @@ rwt.remote.HandlerRegistry.add( "rwt.widgets.MenuItem", {
         }
       }
     },
+    "toolTipMarkupEnabled" : rwt.remote.HandlerUtil.getControlPropertyHandler( "toolTipMarkupEnabled" ),
+    "toolTip" : rwt.remote.HandlerUtil.getControlPropertyHandler( "toolTip" ),
     "selection" : function( widget, value ) {
       if( !widget.hasState( "rwt_SEPARATOR" ) ) {
         widget.setSelection( value );

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/MenuItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2015 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,9 @@
  *    EclipseSource - ongoing development
  ******************************************************************************/
 package org.eclipse.swt.widgets;
+
+import static org.eclipse.swt.internal.widgets.MarkupUtil.isToolTipMarkupEnabledFor;
+import static org.eclipse.swt.internal.widgets.MarkupValidator.isValidationDisabledFor;
 
 import org.eclipse.rap.rwt.internal.lifecycle.WidgetLCA;
 import org.eclipse.swt.SWT;
@@ -22,6 +25,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.internal.widgets.IItemHolderAdapter;
+import org.eclipse.swt.internal.widgets.MarkupValidator;
 import org.eclipse.swt.internal.widgets.menuitemkit.MenuItemLCA;
 
 
@@ -49,6 +53,7 @@ public class MenuItem extends Item {
   private boolean selection;
   private int userId;
   private AcceleratorBinding acceleratorBinding;
+  private String toolTipText;
 
   /**
    * Constructs a new instance of this class given its parent
@@ -277,6 +282,48 @@ public class MenuItem extends Item {
     if( ( style & SWT.SEPARATOR ) == 0 ) {
       super.setImage( image );
     }
+  }
+
+  /**
+   * Sets the receiver's tool tip text to the argument, which
+   * may be null indicating that no tool tip text should be shown.
+   *
+   * @param toolTipText the new tool tip text (or null)
+   *
+   * @exception SWTException <ul>
+   *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+   *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+   * </ul>
+   *
+   * @since 3.22
+   */
+  public void setToolTipText( String toolTipText ) {
+    checkWidget();
+    if(    toolTipText != null
+        && isToolTipMarkupEnabledFor( this )
+        && !isValidationDisabledFor( this ) )
+    {
+      MarkupValidator.getInstance().validate( toolTipText );
+    }
+    this.toolTipText = toolTipText;
+  }
+
+  /**
+   * Returns the receiver's tool tip text, or null if it has
+   * not been set.
+   *
+   * @return the receiver's tool tip text
+   *
+   * @exception SWTException <ul>
+   *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+   *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+   * </ul>
+   *
+   * @since 3.22
+   */
+  public String getToolTipText() {
+    checkWidget();
+    return toolTipText;
   }
 
   /**

--- a/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/widgets/menuitemkit/MenuItemLCA.java
+++ b/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/widgets/menuitemkit/MenuItemLCA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2015 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -50,6 +50,7 @@ public final class MenuItemLCA extends WidgetLCA<MenuItem> {
 
   @Override
   public void preserveValues( MenuItem item ) {
+    WidgetLCAUtil.preserveToolTipText( item, item.getToolTipText() );
     preserveProperty( item, PROP_TEXT, item.getText() );
     preserveProperty( item, PROP_IMAGE, item.getImage() );
     preserveProperty( item, PROP_MENU, item.getMenu() );
@@ -71,6 +72,7 @@ public final class MenuItemLCA extends WidgetLCA<MenuItem> {
   public void renderChanges( MenuItem item ) throws IOException {
     WidgetLCAUtil.renderCustomVariant( item );
     WidgetLCAUtil.renderData( item );
+    WidgetLCAUtil.renderToolTip( item, item.getToolTipText() );
     renderText( item );
     renderMnemonicIndex( item );
     renderProperty( item, PROP_IMAGE, item.getImage(), null );

--- a/examples/org.eclipse.rap.demo.controls/src/org/eclipse/rap/demo/controls/ShellTab.java
+++ b/examples/org.eclipse.rap.demo.controls/src/org/eclipse/rap/demo/controls/ShellTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2015 Innoopract Informationssysteme GmbH.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -288,6 +288,7 @@ public class ShellTab extends ExampleTab {
     editItem.setText( "Edit" );
     MenuItem searchItem = new MenuItem( menuBar, SWT.CASCADE );
     searchItem.setText( "Search" );
+    searchItem.setToolTipText( "Search item tooltip" );
     MenuItem disabledItem = new MenuItem( menuBar, SWT.CASCADE );
     disabledItem.setText( "Disabled" );
     disabledItem.setEnabled( false );
@@ -308,7 +309,9 @@ public class ShellTab extends ExampleTab {
     editItem.setMenu( editMenu );
     MenuItem item;
     new MenuItem( editMenu, SWT.PUSH ).setText( "Copy" );
-    new MenuItem( editMenu, SWT.PUSH ).setText( "Paste" );
+    MenuItem pasteItem = new MenuItem( editMenu, SWT.PUSH );
+    pasteItem.setText( "Paste" );
+    pasteItem.setToolTipText( "Paste item tooltip" );
     new MenuItem( editMenu, SWT.SEPARATOR );
     // cascade menu
     item = new MenuItem( editMenu, SWT.CASCADE );

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/MenuItem_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/MenuItem_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2015 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 
+import org.eclipse.rap.rwt.RWT;
 import org.eclipse.rap.rwt.internal.lifecycle.WidgetLCA;
 import org.eclipse.rap.rwt.testfixture.TestContext;
 import org.eclipse.rap.rwt.testfixture.internal.Fixture;
@@ -34,6 +35,7 @@ import org.eclipse.swt.events.HelpListener;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.internal.widgets.MarkupValidator;
 import org.eclipse.swt.internal.widgets.menuitemkit.MenuItemLCA;
 import org.junit.Before;
 import org.junit.Rule;
@@ -167,6 +169,43 @@ public class MenuItem_Test {
     assertNotNull( image );
     separator.setImage( image );
     assertEquals( null, separator.getImage() );
+  }
+
+  @Test
+  public void testToolTip() {
+    menuItem.setToolTipText( "foo" );
+
+    assertEquals( "foo", menuItem.getToolTipText() );
+  }
+
+  @Test
+  public void testMarkupToolTipTextWithoutMarkupEnabled() {
+    menuItem.setData( RWT.TOOLTIP_MARKUP_ENABLED, Boolean.FALSE );
+
+    try {
+      menuItem.setToolTipText( "invalid xhtml: <<&>>" );
+    } catch( IllegalArgumentException notExpected ) {
+      fail();
+    }
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testMarkupToolTipTextWithMarkupEnabled() {
+    menuItem.setData( RWT.TOOLTIP_MARKUP_ENABLED, Boolean.TRUE );
+
+    menuItem.setToolTipText( "invalid xhtml: <<&>>" );
+  }
+
+  @Test
+  public void testMarkupToolTipTextWithMarkupEnabled_ValidationDisabled() {
+    menuItem.setData( RWT.TOOLTIP_MARKUP_ENABLED, Boolean.TRUE );
+    menuItem.setData( MarkupValidator.MARKUP_VALIDATION_DISABLED, Boolean.TRUE );
+
+    try {
+      menuItem.setToolTipText( "invalid xhtml: <<&>>" );
+    } catch( IllegalArgumentException notExpected ) {
+      fail();
+    }
   }
 
   @Test


### PR DESCRIPTION
Add new API:
- org.eclipse.swt.widgets.MenuItem.setToolTipText(String)
- org.eclipse.swt.widgets.MenuItem.getToolTipText()

To have a tooltip with markup, the RWT.TOOLTIP_MARKUP_ENABLED must be
set as data on the item.

Fix #30