### PR TITLE
Add possibility to disable shutdown request

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/remote/handler/DisplayHandler.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/remote/handler/DisplayHandler.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 EclipseSource and others.
+ * Copyright (c) 2011, 2022 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ rwt.remote.HandlerRegistry.add( "rwt.widgets.Display", {
     "mnemonicActivator",
     "focusControl",
     "enableUiTests",
+    "disableShutdownRequest",
     "activeKeys",
     "cancelKeys"
   ],

--- a/bundles/org.eclipse.rap.rwt/js/rwt/widgets/Display.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/widgets/Display.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 EclipseSource and others.
+ * Copyright (c) 2011, 2022 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ rwt.widgets.Display = function() {
   this._exitConfirmation = null;
   this._hasResizeListener = false;
   this._sendResizeDelayed = false;
+  this._disableShutdownRequest = false;
   this._initialized = false;
   if( rwt.widgets.Display._current !== undefined ) {
     throw new Error( "Display can not be created twice" );
@@ -103,6 +104,10 @@ rwt.widgets.Display.prototype = {
     rwt.widgets.base.Widget._renderHtmlIds = value;
   },
 
+  setDisableShutdownRequest : function( value ) {
+    this._disableShutdownRequest = value;
+  },
+
   getDPI : function() {
     var result = [ 0, 0 ];
     if( typeof screen.systemXDPI == "number" ) {
@@ -181,7 +186,9 @@ rwt.widgets.Display.prototype = {
     this._connection.removeEventListener( "send", this._onSend, this );
     rwt.client.ServerPush.getInstance().setActive( false );
     this._connection.getMessageWriter().appendHead( "shutdown", true );
-    this._sendShutdown();
+    if( !this._disableShutdownRequest ) {
+      this._sendShutdown();
+    }
   },
 
   ///////////////////

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/client/WebClient.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/client/WebClient.java
@@ -154,6 +154,17 @@ public class WebClient implements Client {
    */
   public static final String CSP = PREFIX + ".contentSecurityPolicy";
 
+  /**
+   * Entrypoint property name to disable the shutdown request. Accepts only "true" as property
+   * value.
+   *
+   * @see Application#addEntryPoint(String, Class, Map)
+   * @see Application#addEntryPoint(String, EntryPointFactory, Map)
+   *
+   * @since 3.22
+   */
+  public static final String DISABLE_SHUTDOWN_REQUEST = PREFIX + ".disableShutdownRequest";
+
   public WebClient() {
     initializeServices();
   }

--- a/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/widgets/displaykit/DisplayLCA.java
+++ b/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/widgets/displaykit/DisplayLCA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2017 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,6 +63,7 @@ public class DisplayLCA {
   static final String PROP_EXIT_CONFIRMATION = "exitConfirmation";
   private static final String METHOD_BEEP = "beep";
   private static final String PROP_RESIZE_LISTENER = "listener_Resize";
+  private static final String PROP_DISABLE_SHUTDOWN_REQUEST = "disableShutdownRequest";
 
   public void readData( Display display ) {
     handleOperations( display );
@@ -94,6 +95,7 @@ public class DisplayLCA {
 
   public void render( Display display ) throws IOException {
     renderOverflow( display );
+    renderDisableShutdownRequest( display );
     renderReparentControls();
     renderDisposeWidgets();
     renderExitConfirmation( display );
@@ -154,6 +156,15 @@ public class DisplayLCA {
       String overflow = getEntryPointProperties().get( WebClient.PAGE_OVERFLOW );
       if( overflow != null ) {
         RemoteObjectFactory.getRemoteObject( display ).set( "overflow", overflow );
+      }
+    }
+  }
+
+  private static void renderDisableShutdownRequest( Display display ) {
+    if( !getAdapter( display ).isInitialized() ) {
+      String prop = getEntryPointProperties().get( WebClient.DISABLE_SHUTDOWN_REQUEST );
+      if( "true".equals( prop ) ) {
+        RemoteObjectFactory.getRemoteObject( display ).set( PROP_DISABLE_SHUTDOWN_REQUEST, true );
       }
     }
   }

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/internal/widgets/displaykit/DisplayLCA_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/internal/widgets/displaykit/DisplayLCA_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2017 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -629,6 +629,41 @@ public class DisplayLCA_Test {
 
     TestMessage message = Fixture.getProtocolMessage();
     assertNull( message.findSetOperation( displayId, "overflow" ) );
+  }
+
+  @Test
+  public void testRenderDisableShutdown_whenDisplayIsNotInitialize() throws IOException {
+    Map<String, String> properties = new HashMap<String, String>();
+    properties.put( WebClient.DISABLE_SHUTDOWN_REQUEST, "true" );
+    registerDefaultEntryPoint( TestEntryPoint.class, properties );
+
+    displayLCA.render( display );
+
+    TestMessage message = Fixture.getProtocolMessage();
+    assertTrue( message.findSetProperty( displayId, "disableShutdownRequest" ).asBoolean() );
+  }
+
+  @Test
+  public void testRenderDisableShutdown_whenDisplayIsInitialize() throws IOException {
+    Map<String, String> properties = new HashMap<String, String>();
+    properties.put( WebClient.DISABLE_SHUTDOWN_REQUEST, "true" );
+    registerDefaultEntryPoint( TestEntryPoint.class, properties );
+
+    Fixture.markInitialized( display );
+    displayLCA.render( display );
+
+    TestMessage message = Fixture.getProtocolMessage();
+    assertNull( message.findSetOperation( displayId, "disableShutdownRequest" ) );
+  }
+
+  @Test
+  public void testRenderDisableShutdown_withoutProperties() throws IOException {
+    registerDefaultEntryPoint( TestEntryPoint.class, null );
+
+    displayLCA.render( display );
+
+    TestMessage message = Fixture.getProtocolMessage();
+    assertNull( message.findSetOperation( displayId, "disableShutdownRequest" ) );
   }
 
   private static void setEnableUiTests( boolean value ) {


### PR DESCRIPTION
In certain circumstances it is needed to prevent the execution of
`sendShutdown` within the JavaScript part of RAP. One reason for doing so
is the proper handling of a HTTP redirect response (HTTP code 302/303).

Add the new entry point property `WebClient.DISABLE_SHUTDOWN_REQUEST`
that can be set in the `ApplicationConfiguration`.

Fix #33