### PR TITLE
Fix e4 part stack styling and activation

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -1056,7 +1056,7 @@ public class StackRenderer extends LazyStackRenderer implements IPreferenceChang
 
 			@Override
 			public void handleEvent(org.eclipse.swt.widgets.Event event) {
-				if (event.detail == SWT.MouseDown) {
+				if (event.detail == SWT.None) { // SWT.MouseDown) {
 					CTabFolder ctf = (CTabFolder) event.widget;
 					if (ctf.getSelection() == null)
 						return;

--- a/bundles/org.eclipse.e4.ui.workbench.swt/.classpath
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/.classpath
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-  <classpathentry kind="src" path="src"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
-  <classpathentry kind="output" path="bin"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src-rap"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.e4.ui.workbench.swt/build.properties
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/build.properties
@@ -17,7 +17,8 @@ bin.includes = META-INF/,\
                icons/,\
                about.html,\
                plugin.properties
-source.. = src/
+source.. = src/,\
+           src-rap/
 src.includes = icons/,\
                about.html
 jre.compilation.profile = JavaSE-11

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src-rap/org/eclipse/e4/ui/internal/workbench/swt/StylingEngineImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src-rap/org/eclipse/e4/ui/internal/workbench/swt/StylingEngineImpl.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    EclipseSource - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.e4.ui.internal.workbench.swt;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.e4.ui.services.IStylingEngine;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
+import org.w3c.dom.css.CSSStyleDeclaration;
+
+public class StylingEngineImpl implements IStylingEngine {
+
+	@Override
+	public void setClassname(Object widget, String classname) {
+	}
+
+	@Override
+	public void setId(Object widget, String id) {
+	}
+
+	@Override
+	public void setClassnameAndId(Object widget, String classname, String id) {
+		List<String> parts = Arrays.asList(classname.split(" "));
+		if (parts.contains("MPartStack")) {
+			if (widget instanceof CTabFolder) {
+				CTabFolder folder = (CTabFolder) widget;
+				Display display = folder.getDisplay();
+				if (parts.contains("active")) {
+					folder.setSelectionBackground(display.getSystemColor(SWT.COLOR_LIST_SELECTION));
+				} else {
+					folder.setSelectionBackground((Color) null);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void style(Object widget) {
+	}
+
+	@Override
+	public CSSStyleDeclaration getStyle(Object widget) {
+		return null;
+	}
+
+}

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
@@ -94,7 +94,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.osgi.framework.Bundle;
-import org.w3c.dom.css.CSSStyleDeclaration;
 
 /**
  *
@@ -553,29 +552,7 @@ public class E4Application implements IApplication {
 				new ActiveChildLookupFunction(IServiceConstants.ACTIVE_SHELL,
 						E4Workbench.LOCAL_ACTIVE_SHELL));
 
-		appContext.set(IStylingEngine.class, new IStylingEngine() {
-			@Override
-			public void setClassname(Object widget, String classname) {
-			}
-
-			@Override
-			public void setId(Object widget, String id) {
-			}
-
-			@Override
-			public void style(Object widget) {
-			}
-
-			@Override
-			public CSSStyleDeclaration getStyle(Object widget) {
-				return null;
-			}
-
-			@Override
-			public void setClassnameAndId(Object widget, String classname,
-					String id) {
-			}
-		});
+		appContext.set(IStylingEngine.class, new StylingEngineImpl());
 
 		// translation
 		initializeLocalization(appContext);


### PR DESCRIPTION
The e4 CSS styling engine is not available in the RAP port. Style active
part stack manually in custom StylingEngineImpl class.

The Activate event in RAP does not have a "detail" flag set. Always
activate part stack regardless this flag.