### PR TITLE
Upgrade Apache commons-fileupload to version 1.4.0

### DIFF
--- a/bundles/org.eclipse.rap.fileupload/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.fileupload/META-INF/MANIFEST.MF
@@ -8,10 +8,10 @@ Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.22.0,4.0.0)"
 Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
  javax.servlet.http;version="[3.1.0,5.0.0)",
- org.apache.commons.fileupload;version="[1.3.1,2.0.0)",
- org.apache.commons.fileupload.disk;version="[1.3.1,2.0.0)",
- org.apache.commons.fileupload.servlet;version="[1.3.1,2.0.0)",
- org.apache.commons.io;version="[2.2.0,3.0.0)"
+ org.apache.commons.fileupload;version="[1.4.0,2.0.0)",
+ org.apache.commons.fileupload.disk;version="[1.4.0,2.0.0)",
+ org.apache.commons.fileupload.servlet;version="[1.4.0,2.0.0)",
+ org.apache.commons.io;version="[2.11.0,3.0.0)"
 Export-Package: org.eclipse.rap.fileupload;version="3.22.0",
  org.eclipse.rap.fileupload.internal;version="3.22.0";x-friends:="org.eclipse.rap.fileupload.test"
 Bundle-Localization: plugin

--- a/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
+++ b/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
@@ -39,8 +39,8 @@
     <stringAttribute key="pde.version" value="3.3"/>
     <setAttribute key="selected_target_bundles">
         <setEntry value="com.ibm.icu"/>
-        <setEntry value="org.apache.commons.fileupload"/>
-        <setEntry value="org.apache.commons.io"/>
+        <setEntry value="org.apache.commons.commons-fileupload"/>
+        <setEntry value="org.apache.commons.commons-io"/>
         <setEntry value="org.apache.felix.gogo.command"/>
         <setEntry value="org.apache.felix.gogo.runtime"/>
         <setEntry value="org.apache.felix.gogo.shell"/>

--- a/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
+++ b/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
@@ -39,8 +39,8 @@
     <stringAttribute key="pde.version" value="3.3"/>
     <setAttribute key="selected_target_bundles">
         <setEntry value="com.ibm.icu"/>
-        <setEntry value="org.apache.commons.fileupload"/>
-        <setEntry value="org.apache.commons.io"/>
+        <setEntry value="org.apache.commons.commons-fileupload"/>
+        <setEntry value="org.apache.commons.commons-io"/>
         <setEntry value="org.apache.felix.gogo.command"/>
         <setEntry value="org.apache.felix.gogo.runtime"/>
         <setEntry value="org.apache.felix.gogo.shell"/>

--- a/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
@@ -793,14 +793,14 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.fileupload"
+         id="org.apache.commons.commons-fileupload"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.io"
+         id="org.apache.commons.commons-io"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.eclipse.rap.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.equinox.target.feature/feature.xml
@@ -793,14 +793,14 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.fileupload"
+         id="org.apache.commons.commons-fileupload"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.io"
+         id="org.apache.commons.commons-io"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/releng/org.eclipse.rap.examples.build/rapdemo/org.eclipse.rap.examples.rapdemo.product
+++ b/releng/org.eclipse.rap.examples.build/rapdemo/org.eclipse.rap.examples.rapdemo.product
@@ -11,8 +11,8 @@
 
    <plugins>
       <plugin id="com.ibm.icu"/>
-      <plugin id="org.apache.commons.fileupload"/>
-      <plugin id="org.apache.commons.io"/>
+      <plugin id="org.apache.commons.commons-fileupload"/>
+      <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.felix.gogo.command"/>
       <plugin id="org.apache.felix.gogo.runtime"/>
       <plugin id="org.apache.felix.gogo.shell"/>

--- a/tests/org.eclipse.rap.fileupload.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.fileupload.test/META-INF/MANIFEST.MF
@@ -8,9 +8,9 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
  javax.servlet.http;version="[3.1.0,5.0.0)",
- org.apache.commons.fileupload;version="1.3.1",
- org.apache.commons.fileupload.disk;version="1.3.1",
- org.apache.commons.fileupload.servlet;version="1.3.1",
+ org.apache.commons.fileupload;version="1.4.0",
+ org.apache.commons.fileupload.disk;version="1.4.0",
+ org.apache.commons.fileupload.servlet;version="1.4.0",
  org.eclipse.rap.rwt.testfixture;version="[3.22.0,4.0.0)",
  org.eclipse.rap.rwt.testfixture.internal;version="[3.22.0,4.0.0)",
  org.eclipse.rap.rwt.testfixture.internal.engine;version="[3.22.0,4.0.0)",


### PR DESCRIPTION
This change also includes Apache `commons-io` in version 2.11.0.

Update lower version boundaries of Apache `commons-fileupload` and
`commons-io` to the version of the updated bundles in order to ensure
that the correct versions are selected at runtime.

The new bundles are consumed from Eclipse Platform which retrieves them
from Maven Central. As part of this process, the bundle symbolic name of
the bundles changed:

- `org.apache.commons.fileupload` to `org.apache.commons.commons-fileupload`
- `org.apache.commons.io` to `org.apache.commons.commons-io`

Update features, demo launch configurations, and demo product
definitions to the new name.

This fixes #41.