### PR TITLE
Disable text size measurement for load testing

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/RWTProperties.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/RWTProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2021 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,10 @@ package org.eclipse.rap.rwt.internal;
 public final class RWTProperties {
 
   public static final String SERVICE_HANDLER_BASE_URL = "org.eclipse.rap.rwt.serviceHandlerBaseURL";
-  public static final String SERVICE_HANDLER_USE_RELATIVE_URL = "org.eclipse.rap.rwt.serviceHandlerUseRelativeURL"; 
+  public static final String SERVICE_HANDLER_USE_RELATIVE_URL = "org.eclipse.rap.rwt.serviceHandlerUseRelativeURL";
   public static final String DEVELOPMEMT_MODE = "org.eclipse.rap.rwt.developmentMode";
   public static final String TEXT_SIZE_STORE_SIZE = "org.eclipse.rap.rwt.textSizeStoreSize";
+  public static final String ENABLE_LOAD_TESTS = "org.eclipse.rap.rwt.enableLoadTests";
 
   /*
    * Used in conjunction with <code>WidgetUtil#CUSTOM_WIDGET_ID</code>,
@@ -32,7 +33,7 @@ public final class RWTProperties {
   public static String getServiceHandlerBaseUrl() {
     return System.getProperty( SERVICE_HANDLER_BASE_URL );
   }
-  
+
   public static boolean isUseRelativeURL() {
     return getBooleanProperty( SERVICE_HANDLER_USE_RELATIVE_URL, false );
   }
@@ -43,6 +44,10 @@ public final class RWTProperties {
 
   public static int getTextSizeStoreSize( int defaultValue ) {
     return getIntProperty( TEXT_SIZE_STORE_SIZE, defaultValue );
+  }
+
+  public static boolean isLoadTestsEnabled() {
+    return getBooleanProperty( ENABLE_LOAD_TESTS, false );
   }
 
   public static boolean getBooleanProperty( String name, boolean defaultValue ) {

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/RWTProperties_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/RWTProperties_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 EclipseSource and others.
+ * Copyright (c) 2013, 2022 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal;
 
+import static org.eclipse.rap.rwt.internal.RWTProperties.ENABLE_LOAD_TESTS;
 import static org.eclipse.rap.rwt.internal.RWTProperties.SERVICE_HANDLER_BASE_URL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,6 +35,7 @@ public class RWTProperties_Test {
   public void tearDown() {
     System.getProperties().remove( TEST_PROPERTY );
     System.getProperties().remove( SERVICE_HANDLER_BASE_URL );
+    System.getProperties().remove( ENABLE_LOAD_TESTS );
   }
 
   @Test
@@ -100,6 +102,15 @@ public class RWTProperties_Test {
     System.setProperty( SERVICE_HANDLER_BASE_URL, "http://foo/bar" );
 
     assertEquals( "http://foo/bar", RWTProperties.getServiceHandlerBaseUrl() );
+  }
+
+  @Test
+  public void testIsLoadTestsEnabled() {
+    assertFalse( RWTProperties.isLoadTestsEnabled() );
+
+    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+
+    assertTrue( RWTProperties.isLoadTestsEnabled() );
   }
 
 }

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeUtil_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeUtil_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2014 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,8 +11,12 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal.textsize;
 
+import static org.eclipse.rap.rwt.internal.RWTProperties.ENABLE_LOAD_TESTS;
 import static org.eclipse.rap.rwt.internal.service.ContextProvider.getApplicationContext;
+import static org.eclipse.rap.rwt.internal.textsize.TextSizeUtil.STRING_EXTENT;
+import static org.eclipse.rap.rwt.internal.textsize.TextSizeUtil.TEXT_EXTENT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.rap.rwt.internal.service.ContextProvider;
@@ -43,6 +47,7 @@ public class TextSizeUtil_Test {
   @After
   public void tearDown() {
     Fixture.tearDown();
+    System.getProperties().remove( ENABLE_LOAD_TESTS );
   }
 
   @Test
@@ -121,6 +126,18 @@ public class TextSizeUtil_Test {
   }
 
   @Test
+  public void testStringExtend_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
+    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+
+    TextSizeUtil.stringExtent( getFont(), TEST_STRING );
+
+    assertEquals( 0, getMeasurementItems().length );
+    assertEquals( 0, getProbes().length );
+    assertNotNull( TextSizeStorageUtil.lookup( FONT_DATA, TEST_STRING, -1, STRING_EXTENT ) );
+    assertTrue( ProbeResultStore.getInstance().containsProbeResult( FONT_DATA ) );
+  }
+
+  @Test
   public void testTextExtent_expandLineBreaks() {
     Point singleLine = TextSizeUtil.textExtent( getFont(), "First Line", 0 );
     Point multiLine = TextSizeUtil.textExtent( getFont(), "First Line\nSecond Line", 0 );
@@ -155,6 +172,18 @@ public class TextSizeUtil_Test {
   }
 
   @Test
+  public void testTextExtend_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
+    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+
+    TextSizeUtil.textExtent( getFont(), TEST_STRING, 0, false );
+
+    assertEquals( 0, getMeasurementItems().length );
+    assertEquals( 0, getProbes().length );
+    assertNotNull( TextSizeStorageUtil.lookup( FONT_DATA, TEST_STRING, -1, TEXT_EXTENT ) );
+    assertTrue( ProbeResultStore.getInstance().containsProbeResult( FONT_DATA ) );
+  }
+
+  @Test
   public void testGetCharHeightAssignsUnknownFontToFontProbing() {
     TextSizeUtil.getCharHeight( getFont() );
 
@@ -182,6 +211,16 @@ public class TextSizeUtil_Test {
   }
 
   @Test
+  public void testGetCharHeight_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
+    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+
+    TextSizeUtil.getCharHeight( getFont() );
+
+    assertEquals( 0, getProbes().length );
+    assertTrue( ProbeResultStore.getInstance().containsProbeResult( FONT_DATA ) );
+  }
+
+  @Test
   public void testGetAvgCharWidthAssignsUnknownFontToFontProbing() {
     TextSizeUtil.getAvgCharWidth( getFont() );
 
@@ -206,6 +245,16 @@ public class TextSizeUtil_Test {
     float determined = TextSizeUtil.getAvgCharWidth( getFont() );
 
     assertEquals( 4, determined, 0 );
+  }
+
+  @Test
+  public void testGetAvgCharWidth_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
+    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+
+    TextSizeUtil.getAvgCharWidth( getFont() );
+
+    assertEquals( 0, getProbes().length );
+    assertTrue( ProbeResultStore.getInstance().containsProbeResult( FONT_DATA ) );
   }
 
   @Test


### PR DESCRIPTION
Eliminating text size determination requests for load testing is a
manual work that is not error prone. Always use text size estimation for
load testing automatically.

- add new system property "org.eclipse.rap.rwt.enableLoadTests"
- do not send texts and probes for measurement if the property above is
set
- fill TextSizeStorage and ProbeResultStore with estimated values on
first request