### PR TITLE
Don't query "o.e.r.rwt.enableLoadTests" system property all the time

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeUtil.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeUtil.java
@@ -12,9 +12,9 @@
 package org.eclipse.rap.rwt.internal.textsize;
 
 
-import static org.eclipse.rap.rwt.internal.RWTProperties.isLoadTestsEnabled;
 import static org.eclipse.rap.rwt.internal.textsize.Probe.DEFAULT_PROBE_STRING;
 
+import org.eclipse.rap.rwt.internal.RWTProperties;
 import org.eclipse.rap.rwt.internal.service.ContextProvider;
 import org.eclipse.rap.rwt.internal.service.ServiceStore;
 import org.eclipse.rap.rwt.internal.util.EncodingUtil;
@@ -30,6 +30,12 @@ public class TextSizeUtil {
   static final int STRING_EXTENT = 0;
   static final int TEXT_EXTENT = 1;
   static final int MARKUP_EXTENT = 2;
+
+  // For performance reasons keep the value of the system property in a static field
+  static boolean loadTestsEnabled;
+  static {
+    loadTestsEnabled = RWTProperties.isLoadTestsEnabled();
+  }
 
   public static Point stringExtent( Font font, String string, boolean markup ) {
     if( markup ) {
@@ -57,7 +63,7 @@ public class TextSizeUtil {
   }
 
   public static int getCharHeight( Font font ) {
-    if( isLoadTestsEnabled() ) {
+    if( loadTestsEnabled ) {
       ensureFontProbeResult( font );
     }
     int result;
@@ -71,7 +77,7 @@ public class TextSizeUtil {
   }
 
   public static float getAvgCharWidth( Font font ) {
-    if( isLoadTestsEnabled() ) {
+    if( loadTestsEnabled ) {
       ensureFontProbeResult( font );
     }
     float result;
@@ -102,14 +108,14 @@ public class TextSizeUtil {
   }
 
   private static Point determineTextSize( Font font, String string, int wrapWidth, int mode ) {
-    if( isLoadTestsEnabled() ) {
+    if( loadTestsEnabled ) {
       ensureFontProbeResult( font );
     }
     int normalizedWrapWidth = normalizeWrapWidth( wrapWidth );
     Point result = lookup( font, string, normalizedWrapWidth, mode );
     if( result == null ) {
       result = estimate( font, string, normalizedWrapWidth, mode );
-      if( isLoadTestsEnabled() ) {
+      if( loadTestsEnabled ) {
         store( font, string, normalizedWrapWidth, mode, result );
       } else if( !isTemporaryResize() ) {
         addItemToMeasure( font, string, normalizedWrapWidth, mode );

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeUtil_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeUtil_Test.java
@@ -11,7 +11,6 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal.textsize;
 
-import static org.eclipse.rap.rwt.internal.RWTProperties.ENABLE_LOAD_TESTS;
 import static org.eclipse.rap.rwt.internal.service.ContextProvider.getApplicationContext;
 import static org.eclipse.rap.rwt.internal.textsize.TextSizeUtil.STRING_EXTENT;
 import static org.eclipse.rap.rwt.internal.textsize.TextSizeUtil.TEXT_EXTENT;
@@ -47,7 +46,7 @@ public class TextSizeUtil_Test {
   @After
   public void tearDown() {
     Fixture.tearDown();
-    System.getProperties().remove( ENABLE_LOAD_TESTS );
+    TextSizeUtil.loadTestsEnabled = false;
   }
 
   @Test
@@ -127,7 +126,7 @@ public class TextSizeUtil_Test {
 
   @Test
   public void testStringExtend_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
-    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+    TextSizeUtil.loadTestsEnabled = true;
 
     TextSizeUtil.stringExtent( getFont(), TEST_STRING );
 
@@ -173,7 +172,7 @@ public class TextSizeUtil_Test {
 
   @Test
   public void testTextExtend_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
-    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+    TextSizeUtil.loadTestsEnabled = true;
 
     TextSizeUtil.textExtent( getFont(), TEST_STRING, 0, false );
 
@@ -212,7 +211,7 @@ public class TextSizeUtil_Test {
 
   @Test
   public void testGetCharHeight_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
-    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+    TextSizeUtil.loadTestsEnabled = true;
 
     TextSizeUtil.getCharHeight( getFont() );
 
@@ -249,7 +248,7 @@ public class TextSizeUtil_Test {
 
   @Test
   public void testGetAvgCharWidth_withLoadTestsEnabled_doesNotAssignsStringsToTextSizeMeasurement() {
-    System.setProperty( ENABLE_LOAD_TESTS, "true" );
+    TextSizeUtil.loadTestsEnabled = true;
 
     TextSizeUtil.getAvgCharWidth( getFont() );
 


### PR DESCRIPTION
For performance reasons keep the value of the system property in a
static field.