### PR TITLE
Remove SLF4J Plugin from all features

### DIFF
--- a/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
@@ -1044,18 +1044,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.slf4j.api"
-         download-size="0"
-         install-size="0"
-         version="1.7.30.v20200204-2150"
-         unpack="false"/>
-
-   <plugin
-         id="org.slf4j.api.source"
-         download-size="0"
-         install-size="0"
-         version="1.7.30.v20200204-2150"
-         unpack="false"/>
-
 </feature>

--- a/features/org.eclipse.rap.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.equinox.target.feature/feature.xml
@@ -806,18 +806,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.slf4j.api"
-         download-size="0"
-         install-size="0"
-         version="1.7.30.v20200204-2150"
-         unpack="false"/>
-
-   <plugin
-         id="org.slf4j.api.source"
-         download-size="0"
-         install-size="0"
-         version="1.7.30.v20200204-2150"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
If a Feature includes a Plugin, it usually includes it with a specific name and the version that was in the TP when the feature was build. This prevents consumers from using a slf4j bundle with different symbolic-name or different version in their TP or product.

This is part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588