### PR TITLE
Synchronise SLF4J plugin to Eclipse Platform

### DIFF
--- a/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
+++ b/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
@@ -93,7 +93,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo.controls"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
@@ -92,7 +92,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
@@ -92,7 +92,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
@@ -76,7 +76,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
@@ -92,7 +92,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
+++ b/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
@@ -95,7 +95,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.examples"/>

--- a/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
@@ -1045,17 +1045,10 @@
          unpack="false"/>
 
    <plugin
-         id="org.slf4j.api"
+         id="slf4j.api"
          download-size="0"
          install-size="0"
-         version="1.7.30.v20200204-2150"
-         unpack="false"/>
-
-   <plugin
-         id="org.slf4j.api.source"
-         download-size="0"
-         install-size="0"
-         version="1.7.30.v20200204-2150"
+         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/features/org.eclipse.rap.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.equinox.target.feature/feature.xml
@@ -807,17 +807,10 @@
          unpack="false"/>
 
    <plugin
-         id="org.slf4j.api"
+         id="slf4j.api"
          download-size="0"
          install-size="0"
-         version="1.7.30.v20200204-2150"
-         unpack="false"/>
-
-   <plugin
-         id="org.slf4j.api.source"
-         download-size="0"
-         install-size="0"
-         version="1.7.30.v20200204-2150"
+         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/tests/org.eclipse.rap.rwt.jstest/RWT Client Tests.launch
+++ b/tests/org.eclipse.rap.rwt.jstest/RWT Client Tests.launch
@@ -58,7 +58,7 @@
         <setEntry value="org.osgi.util.position"/>
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
-        <setEntry value="org.slf4j.api"/>
+        <setEntry value="slf4j.api"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.rwt"/>


### PR DESCRIPTION
Use the same slf4j.api bundle as Eclipse Platform that retrieves it from Maven Central instead of the older outdated one from Eclipse Orbit.

Please note that this changes the bundle symbolic name from org.slf4j.api to the shorter slf4j.api which requires to adjust all launch configurations.

This change is supposed to replace pull request #61.
Its companion change in RAP Tools is eclipse-rap/org.eclipse.rap.tools/pull/28.