### PR TITLE
Automatically include all dependencies in output p2 repositories

### DIFF
--- a/releng/org.eclipse.rap.build/repository.e4/pom.xml
+++ b/releng/org.eclipse.rap.build/repository.e4/pom.xml
@@ -53,7 +53,7 @@
           <extraArtifactRepositoryProperties>
             <p2.statsURI>https://download.eclipse.org/stats/rt/rap</p2.statsURI>
           </extraArtifactRepositoryProperties>
-          <includeAllDependencies>false</includeAllDependencies>
+          <includeAllDependencies>true</includeAllDependencies>
           <compress>true</compress>
           <finalName>rap-e4-${unqualifiedVersion}-${buildType}-${build}</finalName>
         </configuration>

--- a/releng/org.eclipse.rap.build/repository/pom.xml
+++ b/releng/org.eclipse.rap.build/repository/pom.xml
@@ -53,7 +53,7 @@
           <extraArtifactRepositoryProperties>
             <p2.statsURI>https://download.eclipse.org/stats/rt/rap</p2.statsURI>
           </extraArtifactRepositoryProperties>
-          <includeAllDependencies>false</includeAllDependencies>
+          <includeAllDependencies>true</includeAllDependencies>
           <compress>true</compress>
           <finalName>rap-${unqualifiedVersion}-${buildType}-${build}</finalName>
         </configuration>


### PR DESCRIPTION
Enable the includeAllDependencies switch when assembling the final distribution p2 repositories. This ensures that all (transitive) dependencies are included and that the resulting p2 repository is self-contained.

In particular this change leads to the inclusion of the SLF4J NOP implementation bundle into the p2 repository unless RAP or any of the upstream projects decide to provide a different implementation. We do not include it in any of our features to make it more unlikely that it gets mirrored into other p2 repositories, or used in any real products.

This is a follow up and enhancement of #80, and should help by implementing eclipse-platform/eclipse.platform.releng.aggregator/issues/588 in the future.