### PR TITLE
Add "slf4j.nop" bundle to all demo launch configurations

### DIFF
--- a/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
+++ b/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
@@ -94,6 +94,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo.controls"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
@@ -93,6 +93,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
@@ -93,6 +93,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
@@ -77,6 +77,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
@@ -93,6 +93,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.demo"/>

--- a/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
+++ b/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
@@ -96,6 +96,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.examples"/>


### PR DESCRIPTION
SLF4J implementation is required for successful execution.