### PR TITLE
Remove upper version constraint from "javax.servlet.*" package imports

### DIFF
--- a/bundles/org.eclipse.rap.filedialog/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.filedialog/META-INF/MANIFEST.MF
@@ -9,6 +9,6 @@ Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)",
  org.eclipse.rap.fileupload;bundle-version="[3.23.0,4.0.0)"
 Export-Package: org.eclipse.swt.internal.widgets;version="3.23.0";x-friends:="org.eclipse.rap.filedialog.test",
  org.eclipse.swt.widgets;version="3.23.0"
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)"
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0"
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.rap.fileupload/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.fileupload/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)"
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.apache.commons.fileupload;version="[1.4.0,2.0.0)",
  org.apache.commons.fileupload.disk;version="[1.4.0,2.0.0)",
  org.apache.commons.fileupload.servlet;version="[1.4.0,2.0.0)",

--- a/bundles/org.eclipse.rap.nebula.widgets.grid/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.nebula.widgets.grid/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-Version: 3.23.0.qualifier
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)"
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)"
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0"
 Export-Package: org.eclipse.nebula.widgets.grid,
  org.eclipse.nebula.widgets.grid.internal;x-friends:="org.eclipse.rap.nebula.widgets.grid.test",
  org.eclipse.nebula.widgets.grid.internal.gridcolumngroupkit;x-friends:="org.eclipse.rap.nebula.widgets.grid.test",

--- a/bundles/org.eclipse.rap.nebula.widgets.richtext/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.nebula.widgets.richtext/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-Version: 3.23.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)"
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0"
 Export-Package: org.eclipse.nebula.widgets.richtext;version="3.23.0",
  org.eclipse.nebula.widgets.richtext.toolbar;version="3.23.0"
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)"

--- a/bundles/org.eclipse.rap.rwt.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.rwt.osgi/META-INF/MANIFEST.MF
@@ -6,9 +6,9 @@ Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.rap.rwt.osgi
 Bundle-Version: 3.23.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Import-Package: javax.servlet;version="[4.0.0,5.0.0)",
- javax.servlet.descriptor;version="[4.0.0,5.0.0)";resolution:=optional,
- javax.servlet.http;version="[4.0.0,5.0.0)",
+Import-Package: javax.servlet;version="4.0.0",
+ javax.servlet.descriptor;version="4.0.0";resolution:=optional,
+ javax.servlet.http;version="4.0.0",
  org.eclipse.rap.rwt.application;version="[3.23.0,4.0.0)",
  org.eclipse.rap.rwt.engine;version="[3.23.0,4.0.0)",
  org.eclipse.rap.rwt.internal.application;version="[3.23.0,4.0.0)",

--- a/bundles/org.eclipse.rap.rwt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.rwt/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
 Provide-Capability: org.eclipse.rap;org.eclipse.rap.rwt=true
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  javax.xml.parsers,
  org.w3c.dom,
  org.xml.sax,

--- a/bundles/org.eclipse.rap.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.ui.workbench/META-INF/MANIFEST.MF
@@ -108,8 +108,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)";visibili
  org.eclipse.core.databinding.observable;bundle-version="[1.2.0,2.0.0)"
 Import-Package: com.ibm.icu.text,
  com.ibm.icu.util,
- javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+ javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  javax.xml.parsers,
  org.eclipse.rap.rwt.osgi;version="[3.23.0,4.0.0)",
  org.osgi.service.event;version="1.3.0",

--- a/bundles/org.eclipse.rap.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.ui/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Import-Package: javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet.http;version="3.1.0",
  org.osgi.service.event;version="1.3.0",
  org.osgi.service.http;version="[1.2.0,2.0.0)"
 Export-Package: org.eclipse.ui.internal;x-friends:="org.eclipse.rap.ui"

--- a/examples/org.eclipse.rap.demo.controls/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.demo.controls/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.eclipse.rap.demo.controls;singleton:=true
 Bundle-Version: 3.23.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet.http;version="3.1.0",
  org.eclipse.core.runtime.jobs
 Export-Package: org.eclipse.rap.demo.controls;version="3.23.0",
  org.eclipse.rap.demo.controls.internal;version="3.23.0";x-internal:=true

--- a/examples/org.eclipse.rap.demo/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.demo/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.rap.ui;bundle-version="[3.23.0,4.0.0)",
  org.eclipse.rap.ui.views;bundle-version="[3.23.0,4.0.0)",
  org.eclipse.rap.ui.forms;bundle-version="[3.23.0,4.0.0)"
-Import-Package: javax.servlet.http;version="[3.1.0,5.0.0)"
+Import-Package: javax.servlet.http;version="3.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.rap.demo;version="3.23.0";x-internal:=true,
  org.eclipse.rap.demo.actions;version="3.23.0";x-internal:=true,

--- a/examples/org.eclipse.rap.examples.pages/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.examples.pages/META-INF/MANIFEST.MF
@@ -13,6 +13,6 @@ Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)",
 Export-Package: org.eclipse.rap.examples.pages;version="3.23.0",
  org.eclipse.rap.examples.pages.internal;version="3.23.0";x-internal:=true
 Bundle-Activator: org.eclipse.rap.examples.pages.internal.Activator
-Import-Package: javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet.http;version="3.1.0",
  org.eclipse.rap.examples;version="[3.23.0,4.0.0)",
  org.osgi.framework;version="[1.6.0,2.0.0)"

--- a/examples/org.eclipse.rap.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.examples/META-INF/MANIFEST.MF
@@ -8,8 +8,8 @@ Bundle-Activator: org.eclipse.rap.examples.internal.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.osgi.framework;version="[1.6.0,2.0.0)",
  org.osgi.util.tracker;version="[1.5.0,2.0.0)"
 Export-Package: org.eclipse.rap.examples;version="3.23.0",

--- a/examples/org.eclipse.rap.filedialog.demo.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.filedialog.demo.examples/META-INF/MANIFEST.MF
@@ -4,8 +4,8 @@ Bundle-Name: %Bundle-Name
 Bundle-Version: 3.23.0.qualifier
 Bundle-SymbolicName: org.eclipse.rap.filedialog.demo.examples
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.eclipse.rap.fileupload;version="[3.23.0,4.0.0)",
  org.osgi.framework;version="1.3.0"
 Bundle-Vendor: %Bundle-Vendor

--- a/tests/org.eclipse.rap.fileupload.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.fileupload.test/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Fragment-Host: org.eclipse.rap.fileupload;bundle-version="[3.23.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.apache.commons.fileupload;version="1.4.0",
  org.apache.commons.fileupload.disk;version="1.4.0",
  org.apache.commons.fileupload.servlet;version="1.4.0",

--- a/tests/org.eclipse.rap.rwt.cluster.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.cluster.test/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)",
  org.eclipse.rap.rwt.cluster.testfixture;bundle-version="[3.23.0,4.0.0)",
  org.junit;bundle-version="4.8.2"
-Import-Package: javax.servlet;version="[2.5.0,5.0.0)",
- javax.servlet.http;version="[2.5.0,5.0.0)"
+Import-Package: javax.servlet;version="2.5.0",
+ javax.servlet.http;version="2.5.0"

--- a/tests/org.eclipse.rap.rwt.cluster.testfixture/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.cluster.testfixture/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-SymbolicName: org.eclipse.rap.rwt.cluster.testfixture
 Bundle-Version: 3.23.0.qualifier
 Bundle-Vendor: Eclipse.org - RAP
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.apache.catalina;version="[7.0.0,8.0.0)",
  org.apache.catalina.connector;version="[7.0.0,8.0.0)",
  org.apache.catalina.core;version="[7.0.0,8.0.0)",

--- a/tests/org.eclipse.rap.rwt.jstest/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.jstest/META-INF/MANIFEST.MF
@@ -11,8 +11,8 @@ Export-Package: org.eclipse.rap.rwt.jstest,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.equinox.http.jetty;bundle-version="[2.0.0,4.0.0)",
  org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)"
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.osgi.framework;version="1.6.0",
  org.osgi.service.http;version="1.2.1",
  org.osgi.util.tracker;version="1.5.0"

--- a/tests/org.eclipse.rap.rwt.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.test/META-INF/MANIFEST.MF
@@ -9,8 +9,8 @@ Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)"
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.http;version="[3.1.0,5.0.0)",
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.eclipse.rap.rwt.testfixture;version="[3.23.0,4.0.0)",
  org.eclipse.rap.rwt.testfixture.internal;version="[3.23.0,4.0.0)",
  org.eclipse.rap.rwt.testfixture.internal.engine;version="[3.23.0,4.0.0)",

--- a/tests/org.eclipse.rap.rwt.testfixture/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.testfixture/META-INF/MANIFEST.MF
@@ -7,9 +7,9 @@ Bundle-Version: 3.23.0.qualifier
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[3.23.0,4.0.0)"
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet;version="[4.0.0,5.0.0)",
- javax.servlet.descriptor;version="[4.0.0,5.0.0)",
- javax.servlet.http;version="[4.0.0,5.0.0)",
+Import-Package: javax.servlet;version="4.0.0",
+ javax.servlet.descriptor;version="4.0.0",
+ javax.servlet.http;version="4.0.0",
  org.junit.rules;version="4.11.0",
  org.junit.runner;version="4.11.0",
  org.junit.runners.model;version="4.11.0"


### PR DESCRIPTION
Tomcat 10.x has an automated tool for converting "javax.servlet" package imports to "jakarta.servlet". The upper version constraint prevents the conversion process to produce a working war file.

A 5+ version of "javax.servlet" is extremely unlikely, and therefore the upper version constraint is useless.