### PR TITLE
Catch and process fetch errors

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/remote/Request.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/remote/Request.js
@@ -123,6 +123,10 @@ rwt.remote.Request.prototype = {
           event.target.dispose();
         } );
       }
+    } ).catch( function() {
+      if( event.target._error ) {
+        event.target._error( event );
+      }
     } );
   },
 


### PR DESCRIPTION
Since RAP switched to use fetch instead of XHR, the connection errors are not processed. Fetch promises only reject with a TypeError when a network error occurs.

Fix #88