### PR TITLE
Improve connection error handling when fetch is used

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/remote/Request.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/remote/Request.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 EclipseSource and others.
+ * Copyright (c) 2012, 2023 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -124,6 +124,7 @@ rwt.remote.Request.prototype = {
         } );
       }
     } ).catch( function() {
+      event.status = 0;
       if( event.target._error ) {
         event.target._error( event );
       }


### PR DESCRIPTION
In case of connection error, fetch throws an error. Connection.js#_isConnectionError relies on status = 0 in order to recognize it.

Set status to zero in fecth catch block.