### PR TITLE
Add possibility to get startup parameters from initial POST request

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/widgets/Display.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/widgets/Display.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 EclipseSource and others.
+ * Copyright (c) 2011, 2023 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,9 +11,12 @@
 
 namespace( "rwt.widgets" );
 
-rwt.widgets.Display = function() {
+rwt.widgets.Display = function( properties ) {
   this._document = rwt.widgets.base.ClientDocument.getInstance();
   this._connection = rwt.remote.Connection.getInstance();
+  if( properties ) {
+    this._startupParameters = properties.startupParameters;
+  }
   this._exitConfirmation = null;
   this._hasResizeListener = false;
   this._sendResizeDelayed = false;
@@ -254,8 +257,8 @@ rwt.widgets.Display.prototype = {
   },
 
   _appendStartupParameters : function() {
-    var parameters = rwt.runtime.System.getInstance().getStartupParameters();
-    if( parameters ) {
+    if( this._startupParameters ) {
+      var parameters = rwt.runtime.System.getInstance()._parseQueryString( this._startupParameters );
       var writer = this._connection.getMessageWriter();
       writer.appendSet( "rwt.client.StartupParameters", "parameters", parameters );
     }

--- a/tests/org.eclipse.rap.rwt.jstest/RWT Client Tests.launch
+++ b/tests/org.eclipse.rap.rwt.jstest/RWT Client Tests.launch
@@ -59,6 +59,7 @@
         <setEntry value="org.osgi.util.promise"/>
         <setEntry value="org.osgi.util.xml"/>
         <setEntry value="slf4j.api"/>
+        <setEntry value="slf4j.nop@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.rap.rwt"/>

--- a/tests/org.eclipse.rap.rwt.jstest/js/org/eclipse/rwt/test/tests/DisplayTest.js
+++ b/tests/org.eclipse.rap.rwt.jstest/js/org/eclipse/rwt/test/tests/DisplayTest.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 EclipseSource and others.
+ * Copyright (c) 2011, 2023 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -151,11 +151,7 @@ rwt.qx.Class.define( "org.eclipse.rwt.test.tests.DisplayTest", {
     },
 
     testSendStartupParameters : function() {
-      var system = rwt.runtime.System.getInstance();
-      var oldGetStartupParameters = system.getStartupParameters;
-      system.getStartupParameters = function() {
-        return { param1 : [ "foo" ], param2 : [ "bar" ] };
-      };
+      display._startupParameters = "param1=foo&param2=bar"
 
       display._appendStartupParameters();
       rwt.remote.Connection.getInstance().send();
@@ -164,7 +160,7 @@ rwt.qx.Class.define( "org.eclipse.rwt.test.tests.DisplayTest", {
       var expected = { param1 : [ "foo" ], param2 : [ "bar" ] };
       var actual = message.findSetProperty( "rwt.client.StartupParameters", "parameters" );
       assertEquals( expected, actual );
-      system.getStartupParameters = oldGetStartupParameters;
+      delete display._startupParameters;
     },
 
     testSendColorDepth : function() {

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/service/StartupJson_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/service/StartupJson_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 EclipseSource and others.
+ * Copyright (c) 2012, 2023 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,10 +14,12 @@ import static org.eclipse.rap.rwt.internal.service.ContextProvider.getApplicatio
 import static org.eclipse.rap.rwt.internal.service.StartupJson.DISPLAY_TYPE;
 import static org.eclipse.rap.rwt.internal.service.StartupJson.METHOD_LOAD_ACTIVE_THEME;
 import static org.eclipse.rap.rwt.internal.service.StartupJson.METHOD_LOAD_FALLBACK_THEME;
+import static org.eclipse.rap.rwt.internal.service.StartupJson.PROPERTY_STARTUP_PARAMETERS;
 import static org.eclipse.rap.rwt.internal.service.StartupJson.PROPERTY_URL;
 import static org.eclipse.rap.rwt.internal.service.StartupJson.THEME_STORE_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -89,6 +91,47 @@ public class StartupJson_Test {
 
     TestMessage message = new TestMessage( content );
     assertNotNull( message.findCreateOperation( "w1" ) );
+  }
+
+  @Test
+  public void testGet_createDisplay_withoutStartupParameters() {
+    JsonObject content = StartupJson.get();
+
+    TestMessage message = new TestMessage( content );
+    JsonObject properties = message.findCreateOperation( "w1" ).getProperties();
+    assertNull( properties.get( PROPERTY_STARTUP_PARAMETERS ) );
+  }
+
+  @Test
+  public void testGet_createDisplay_withStartupParameters() {
+    TestRequest request = ( TestRequest )ContextProvider.getRequest();
+    request.addParameter( "foo", "1" );
+    request.addParameter( "bar", "2" );
+
+    JsonObject content = StartupJson.get();
+
+    TestMessage message = new TestMessage( content );
+    JsonObject properties = message.findCreateOperation( "w1" ).getProperties();
+    String startupParameters = properties.get( PROPERTY_STARTUP_PARAMETERS ).asString();
+    assertTrue( startupParameters.contains( "foo=1" ) );
+    assertTrue( startupParameters.contains( "bar=2" ) );
+  }
+
+  @Test
+  public void testGet_createDisplay_withStartupParametersAndMultipleValues() {
+    TestRequest request = ( TestRequest )ContextProvider.getRequest();
+    request.addParameter( "foo", "1" );
+    request.addParameter( "foo", "3" );
+    request.addParameter( "bar", "2" );
+
+    JsonObject content = StartupJson.get();
+
+    TestMessage message = new TestMessage( content );
+    JsonObject properties = message.findCreateOperation( "w1" ).getProperties();
+    String startupParameters = properties.get( PROPERTY_STARTUP_PARAMETERS ).asString();
+    assertTrue( startupParameters.contains( "foo=1" ) );
+    assertTrue( startupParameters.contains( "foo=3" ) );
+    assertTrue( startupParameters.contains( "bar=2" ) );
   }
 
   @Test


### PR DESCRIPTION
The initial RAP request POST or GET does not initiate UI session. There is a client service StartupParameters to extract the startup  parameters from URL query string and send them to the server with the first UI request. With the initial POST request this is not working.

In order to fix it, get the startup parameters from the initial GET/POST request on the server and send them back to client-side Display object during the creation in StartupJson#appendCreateDisplay.

Fix #58