### PR TITLE
Add support for the altgr modifier as a combination of CTRL and ALT (like in SWT)

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/event/DomEvent.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/event/DomEvent.js
@@ -142,6 +142,16 @@ rwt.qx.Class.define( "rwt.event.DomEvent", {
     isAltPressed : function() {
       return this.getDomEvent().altKey;
     },
+    
+    /**
+     * Returns whether both the Alt and Ctrl keys are pressed or the AltGr key is pressed.
+     *
+     * @type member
+     * @return {Boolean} whether both the Alt and Ctrl keys are pressed or the AltGr key is pressed.
+     */
+    isAltGrPressed : function() {
+      return this.getDomEvent().getModifierState("AltGraph");
+    },
 
     /**
      * Returns whether the the meta key is pressed.

--- a/bundles/org.eclipse.rap.rwt/js/rwt/scripting/EventProxy.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/scripting/EventProxy.js
@@ -316,6 +316,7 @@ function setStateMask( event, originalEvent ) {
   event.stateMask |= originalEvent.isCtrlPressed() ? SWT.CTRL : 0;
   event.stateMask |= originalEvent.isAltPressed() ? SWT.ALT : 0;
   event.stateMask |= originalEvent.isMetaPressed() ? SWT.COMMAND : 0;
+  event.stateMask |= originalEvent.isAltGrPressed() ? SWT.CTRL | SWT.ALT : 0;
 }
 
 function postProcessVerifyEvent( event, wrappedEvent, originalEvent ) {


### PR DESCRIPTION
When you press the ALT GR Key in a SWT Application the flags for SWT.CTRL and SWT.ALT are both set in the stateMask Property of the Event. However this does not work on RAP.