### PR TITLE
Add internal API to destroy internal image

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/internal/graphics/InternalImageFactory.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/internal/graphics/InternalImageFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2015 EclipseSource and others.
+ * Copyright (c) 2010, 2023 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,7 @@ public class InternalImageFactory {
 
   public InternalImage findInternalImage( final String fileName ) {
     return cache.get( fileName, new InstanceCreator<String, InternalImage>() {
+      @Override
       public InternalImage createInstance( String fileName ) {
         return createInternalImage( fileName );
       }
@@ -50,6 +51,7 @@ public class InternalImageFactory {
     final ImageData imageData = readImageData( bufferedStream );
     final String path = createGeneratedImagePath( imageData );
     return cache.get( path, new InstanceCreator<String, InternalImage>() {
+      @Override
       public InternalImage createInstance( String path ) {
         return createInternalImage( path, bufferedStream, imageData );
       }
@@ -59,6 +61,7 @@ public class InternalImageFactory {
   public InternalImage findInternalImage( final ImageData imageData ) {
     final String path = createGeneratedImagePath( imageData );
     return cache.get( path, new InstanceCreator<String, InternalImage>() {
+      @Override
       public InternalImage createInstance( String path ) {
         InputStream stream = createInputStream( imageData );
         return createInternalImage( path, stream, imageData );
@@ -68,6 +71,7 @@ public class InternalImageFactory {
 
   InternalImage findInternalImage( String key, final InputStream inputStream ) {
     return cache.get( key, new InstanceCreator<String, InternalImage>() {
+      @Override
       public InternalImage createInstance( String key ) {
         BufferedInputStream bufferedStream = new BufferedInputStream( inputStream );
         ImageData imageData = readImageData( bufferedStream );
@@ -75,6 +79,11 @@ public class InternalImageFactory {
         return createInternalImage( path, bufferedStream, imageData );
       }
     } );
+  }
+
+  public void destroyInternalImage( String key ) {
+    InternalImage internalImage = cache.remove( key );
+    RWT.getResourceManager().unregister( internalImage.getResourceName() );
   }
 
   static ImageData readImageData( InputStream stream ) throws SWTException {

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/internal/graphics/InternalImageFactory_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/internal/graphics/InternalImageFactory_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2014 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2023 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package org.eclipse.swt.internal.graphics;
 
 import static org.eclipse.rap.rwt.testfixture.internal.TestUtil.createImage;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -213,6 +214,33 @@ public class InternalImageFactory_Test {
     stream.close();
 
     assertTrue( internalImage.getResourceName().endsWith( ".png" ) );
+  }
+
+  @Test
+  public void testDestroyInternalImage_deregisterFromResourceManager() throws IOException {
+    InputStream stream1 = CLASS_LOADER.getResourceAsStream( Fixture.IMAGE_100x50 );
+    InternalImage internalImage1 = internalImageFactory.findInternalImage( "image.png", stream1);
+    stream1.close();
+
+    assertTrue( RWT.getResourceManager().isRegistered( internalImage1.getResourceName() ) );
+
+    internalImageFactory.destroyInternalImage( "image.png" );
+
+    assertFalse( RWT.getResourceManager().isRegistered( internalImage1.getResourceName() ) );
+  }
+
+  @Test
+  public void testDestroyInternalImage_removeFromCache() throws IOException {
+    InputStream stream1 = CLASS_LOADER.getResourceAsStream( Fixture.IMAGE_100x50 );
+    InternalImage internalImage1 = internalImageFactory.findInternalImage( "image.png", stream1);
+    stream1.close();
+
+    internalImageFactory.destroyInternalImage( "image.png" );
+
+    InputStream stream2 = CLASS_LOADER.getResourceAsStream( Fixture.IMAGE_100x50 );
+    InternalImage internalImage2 = internalImageFactory.findInternalImage( "image.png", stream2);
+    stream2.close();
+    assertNotSame( internalImage1, internalImage2 );
   }
 
   private ImageData createImageDataWithoutType() {


### PR DESCRIPTION
In some cases it will be useful to destroy the internal image. This includes:
* remove the internal image from `InternalImageFactory.cache`
* deregister the resource from `ResourceManager` to remove the file from the file system