### PR TITLE
Don't delegate to deprecated servlet APIs

### DIFF
--- a/bundles/org.eclipse.rap.rwt.osgi/src/org/eclipse/rap/rwt/osgi/internal/HttpSessionWrapper.java
+++ b/bundles/org.eclipse.rap.rwt.osgi/src/org/eclipse/rap/rwt/osgi/internal/HttpSessionWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Frank Appel and others.
+ * Copyright (c) 2011, 2023 Frank Appel and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.osgi.internal;
 
+import java.util.Collections;
 import java.util.Enumeration;
 
 import javax.servlet.ServletContext;
@@ -72,7 +73,7 @@ public class HttpSessionWrapper implements HttpSession {
   @Override
   @Deprecated
   public Object getValue( String name ) {
-    return session.getValue( name );
+    return session.getAttribute( name );
   }
 
   @Override
@@ -83,7 +84,7 @@ public class HttpSessionWrapper implements HttpSession {
   @Override
   @Deprecated
   public String[] getValueNames() {
-    return session.getValueNames();
+    return Collections.list( session.getAttributeNames() ).toArray( new String[ 0 ] );
   }
 
   @Override
@@ -94,7 +95,7 @@ public class HttpSessionWrapper implements HttpSession {
   @Override
   @Deprecated
   public void putValue( String name, Object value ) {
-    session.putValue( name, value );
+    session.setAttribute( name, value );
   }
 
   @Override
@@ -105,7 +106,7 @@ public class HttpSessionWrapper implements HttpSession {
   @Override
   @Deprecated
   public void removeValue( String name ) {
-    session.removeValue( name );
+    session.removeAttribute( name );
   }
 
   @Override

--- a/bundles/org.eclipse.rap.rwt.osgi/src/org/eclipse/rap/rwt/osgi/internal/ServletContextWrapper.java
+++ b/bundles/org.eclipse.rap.rwt.osgi/src/org/eclipse/rap/rwt/osgi/internal/ServletContextWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Frank Appel and others.
+ * Copyright (c) 2011, 2023 Frank Appel and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,7 @@ package org.eclipse.rap.rwt.osgi.internal;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.EventListener;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import javax.servlet.*;
 import javax.servlet.ServletRegistration.Dynamic;
@@ -91,34 +86,33 @@ class ServletContextWrapper implements ServletContext {
   @Override
   @Deprecated
   public Servlet getServlet( String name ) throws ServletException {
-    return servletContext.getServlet( name );
+    return null;
   }
 
   @Override
   @Deprecated
   public Enumeration<Servlet> getServlets() {
-    return servletContext.getServlets();
+    return Collections.emptyEnumeration();
   }
 
   @Override
   @Deprecated
   public Enumeration<String> getServletNames() {
-    return servletContext.getServletNames();
+    return Collections.emptyEnumeration();
   }
 
   @Override
-  public void log( String msg ) {
-    servletContext.log( msg );
-  }
-
-  @Override
-  @Deprecated
-  public void log( Exception exception, String msg ) {
-    servletContext.log( exception, msg );
+  public void log( String message ) {
+    servletContext.log( message );
   }
 
   @Override
   @Deprecated
+  public void log( Exception exception, String message ) {
+    servletContext.log( message, exception );
+  }
+
+  @Override
   public void log( String message, Throwable throwable ) {
     servletContext.log( message, throwable );
   }

--- a/tests/org.eclipse.rap.rwt.osgi.test/src/org/eclipse/rap/rwt/osgi/internal/HttpSessionWrapper_Test.java
+++ b/tests/org.eclipse.rap.rwt.osgi.test/src/org/eclipse/rap/rwt/osgi/internal/HttpSessionWrapper_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2012 Frank Appel and others.
+ * Copyright (c) 2011, 2023 Frank Appel and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,12 @@ package org.eclipse.rap.rwt.osgi.internal;
 
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
@@ -30,6 +35,7 @@ public class HttpSessionWrapper_Test {
   @Before
   public void setUp() {
     session = mock( HttpSession.class );
+    when( session.getAttributeNames() ).thenReturn( Collections.emptyEnumeration() );
     servletContext = mock( ServletContext.class );
     wrapper = new HttpSessionWrapper( session, servletContext );
   }
@@ -57,21 +63,21 @@ public class HttpSessionWrapper_Test {
     wrapper.setAttribute( name, object );
     wrapper.setMaxInactiveInterval( 3 );
 
-    verify( session ).getAttribute( "name" );
-    verify( session ).getAttributeNames();
+    verify( session, times( 2 ) ).getAttribute( "name" );
+    verify( session, times( 2 ) ).getAttributeNames();
     verify( session ).getCreationTime();
     verify( session ).getId();
     verify( session ).getLastAccessedTime();
     verify( session ).getMaxInactiveInterval();
     verify( session ).getSessionContext();
-    verify( session ).getValue( name );
-    verify( session ).getValueNames();
+    verify( session, never() ).getValue( name );
+    verify( session, never() ).getValueNames();
     verify( session ).invalidate();
     verify( session ).isNew();
-    verify( session ).putValue( name, object );
-    verify( session ).removeAttribute( name );
-    verify( session ).removeValue( name );
-    verify( session ).setAttribute( name, object );
+    verify( session, never() ).putValue( name, object );
+    verify( session, times( 2 ) ).removeAttribute( name );
+    verify( session, never() ).removeValue( name );
+    verify( session, times( 2 ) ).setAttribute( name, object );
     verify( session ).setMaxInactiveInterval( 3 );
   }
 

--- a/tests/org.eclipse.rap.rwt.osgi.test/src/org/eclipse/rap/rwt/osgi/internal/ServletContextWrapper_Test.java
+++ b/tests/org.eclipse.rap.rwt.osgi.test/src/org/eclipse/rap/rwt/osgi/internal/ServletContextWrapper_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 Frank Appel and others.
+ * Copyright (c) 2011, 2023 Frank Appel and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,18 @@
 package org.eclipse.rap.rwt.osgi.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Enumeration;
+
+import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 
 import org.eclipse.rap.rwt.application.ApplicationConfiguration;
@@ -120,25 +125,28 @@ public class ServletContextWrapper_Test {
   @Test
   public void testGetServlet() throws Exception {
     String name = "name";
-    wrapper.getServlet( name );
+    Servlet servlet = wrapper.getServlet( name );
 
-    verify( context ).getServlet( name );
+    verify( context, never() ).getServlet( name );
+    assertNull( servlet );
   }
 
   @SuppressWarnings( "deprecation" )
   @Test
   public void testGetServlets() {
-    wrapper.getServlets();
+    Enumeration<Servlet> servlets = wrapper.getServlets();
 
-    verify( context ).getServlets();
+    verify( context, never() ).getServlets();
+    assertFalse( servlets.hasMoreElements() );
   }
 
   @SuppressWarnings( "deprecation" )
   @Test
   public void testGetServletNames() {
-    wrapper.getServletNames();
+    Enumeration<String> servletNames = wrapper.getServletNames();
 
-    verify( context ).getServletNames();
+    verify( context, never() ).getServletNames();
+    assertFalse( servletNames.hasMoreElements() );
   }
 
   @Test
@@ -156,10 +164,10 @@ public class ServletContextWrapper_Test {
     String msg = "msg";
     wrapper.log( exception, msg );
 
-    verify( context ).log( exception, msg );
+    verify( context, never() ).log( exception, msg );
+    verify( context ).log( msg, exception );
   }
 
-  @SuppressWarnings( "deprecation" )
   @Test
   public void testLogWithThrowable() {
     Throwable throwable = new Throwable();


### PR DESCRIPTION
The following APIs have been deprecated since Servlet 2.x and removed in
Servlet 6:
* ServletContextWrapper
  - getServlet(String)
  - getServlets(),
  - getServletNames(),
  - log(Exception, String)
* HttpSessionWrapper
  - getValue(String)
  - getValueNames()
  - putValue(String, Object)
  - removeValue(String)

There is no replacement for getSessionContext() as the complete class
HttpSessionContext is deprecated. Keep it for now.
For others use their replacement instead.