### PR TITLE
Clear selected cells when setting lower item count

### DIFF
--- a/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 EclipseSource and others.
+ * Copyright (c) 2012, 2023 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -307,6 +307,9 @@ public class Grid extends Composite {
   public void setItemCount( int count ) {
     checkWidget();
     int itemCount = Math.max( 0, count );
+    if( itemCount < items.size() ) {
+      selectedCells.clear();
+    }
     while( itemCount < items.size() ) {
       int flatIndex = items.size() - 1;
       items.get( flatIndex ).dispose( flatIndex );

--- a/tests/org.eclipse.rap.nebula.widgets.grid.test/src/org/eclipse/nebula/widgets/grid/Grid_Test.java
+++ b/tests/org.eclipse.rap.nebula.widgets.grid.test/src/org/eclipse/nebula/widgets/grid/Grid_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 EclipseSource and others.
+ * Copyright (c) 2012, 2023 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -169,6 +169,18 @@ public class Grid_Test {
     grid.setItemCount( 12 );
 
     assertTrue( Arrays.equals( items, grid.getItems() ) );
+  }
+
+  @Test
+  public void testSetItemCount_WithSelectedCells() {
+    createGridItems( grid, 3, 3 );
+    createGridColumns( grid, 3, SWT.NONE );
+    grid.setCellSelectionEnabled( true );
+    grid.setCellSelection( new Point( 1, 1 ) );
+
+    grid.setItemCount( 1 );
+
+    assertEquals( 0, grid.getCellSelectionCount() );
   }
 
   @Test


### PR DESCRIPTION
To avoid invalid selected cells when items are reduced, we have to clear the cell selection.

Fix #135