### PR TITLE
Upgrade to new org.mozilla.rhino version provided by Orbit

### DIFF
--- a/bundles/org.eclipse.rap.rwt/pom.xml
+++ b/bundles/org.eclipse.rap.rwt/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.mozilla</groupId>
       <artifactId>rhino</artifactId>
-      <version>1.7.10</version>
+      <version>1.7.14</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/releng/org.eclipse.rap.clientbuilder/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.rap.clientbuilder/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.eclipse.rap.clientbuilder
 Bundle-Version: 3.27.0.qualifier
 Bundle-Vendor: Eclipse.org - RAP
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.mozilla.javascript;bundle-version="[1.7.10,1.8.0)",
+Require-Bundle: org.mozilla.rhino;bundle-version="[1.7.14,1.8.0)",
  org.junit;bundle-version="4.11.0";resolution:=optional
 Export-Package: org.eclipse.rap.clientbuilder;version="3.27.0"


### PR DESCRIPTION
Orbit is migrating from hand-crafted bundles to pristine versions from Maven central. Part of this is the bundle symbolic name change from `org.mozilla.javascript` to `org.mozilla.rhino`.

Because this includes an upgrade of the version, the reference in the RWT build needs to be in sync again, otherwise the build breaks.