### PR TITLE
Update IStructuredSelection to make it an Iterable

### DIFF
--- a/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/viewers/IStructuredSelection.java
+++ b/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/viewers/IStructuredSelection.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * A selection containing elements.
  */
-public interface IStructuredSelection extends ISelection {
+public interface IStructuredSelection extends ISelection, Iterable {
     /**
      * Returns the first element in this selection, or <code>null</code>
      * if the selection is empty.
@@ -30,6 +30,7 @@ public interface IStructuredSelection extends ISelection {
      *
      * @return an iterator over the selected elements
      */
+    @Override
     public Iterator iterator();
 
     /**


### PR DESCRIPTION
This would align this to the standard Jface IStructuredSelection, which was made an Iterable long ago:

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=234331

and the corresponding commit: https://git.eclipse.org/c/platform/eclipse.platform.ui.git/commit/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/IStructuredSelection.java?id=a831a2e350432c0824e8df41f01fcd50390a063a