### PR TITLE
Add mode to make text-size-store session scoped

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/RWTProperties.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/RWTProperties.java
@@ -18,6 +18,7 @@ public final class RWTProperties {
   public static final String SERVICE_HANDLER_USE_RELATIVE_URL = "org.eclipse.rap.rwt.serviceHandlerUseRelativeURL";
   public static final String DEVELOPMEMT_MODE = "org.eclipse.rap.rwt.developmentMode";
   public static final String TEXT_SIZE_STORE_SIZE = "org.eclipse.rap.rwt.textSizeStoreSize";
+  public static final String TEXT_SIZE_STORE_SESSION_SCOPED = "org.eclipse.rap.rwt.textSizeStoreSessionScoped";
   public static final String ENABLE_LOAD_TESTS = "org.eclipse.rap.rwt.enableLoadTests";
 
   /*
@@ -44,6 +45,10 @@ public final class RWTProperties {
 
   public static int getTextSizeStoreSize( int defaultValue ) {
     return getIntProperty( TEXT_SIZE_STORE_SIZE, defaultValue );
+  }
+
+  public static boolean isTextSizeStoreSessionScoped() {
+    return getBooleanProperty( TEXT_SIZE_STORE_SESSION_SCOPED, false );
   }
 
   public static boolean isLoadTestsEnabled() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/UISessionImpl.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/UISessionImpl.java
@@ -26,12 +26,15 @@ import javax.servlet.http.HttpSessionBindingListener;
 
 import org.eclipse.rap.rwt.client.Client;
 import org.eclipse.rap.rwt.client.service.ClientInfo;
+import org.eclipse.rap.rwt.internal.RWTProperties;
 import org.eclipse.rap.rwt.internal.application.ApplicationContextImpl;
 import org.eclipse.rap.rwt.internal.client.ClientMessages;
 import org.eclipse.rap.rwt.internal.client.ClientSelector;
 import org.eclipse.rap.rwt.internal.lifecycle.ContextUtil;
 import org.eclipse.rap.rwt.internal.lifecycle.ISessionShutdownAdapter;
 import org.eclipse.rap.rwt.internal.remote.ConnectionImpl;
+import org.eclipse.rap.rwt.internal.textsize.ProbeStore;
+import org.eclipse.rap.rwt.internal.textsize.TextSizeStorage;
 import org.eclipse.rap.rwt.internal.util.ParamCheck;
 import org.eclipse.rap.rwt.internal.util.SerializableLock;
 import org.eclipse.rap.rwt.remote.Connection;
@@ -40,7 +43,6 @@ import org.eclipse.rap.rwt.service.ApplicationContextListener;
 import org.eclipse.rap.rwt.service.UISession;
 import org.eclipse.rap.rwt.service.UISessionEvent;
 import org.eclipse.rap.rwt.service.UISessionListener;
-
 
 public class UISessionImpl
   implements UISession, ApplicationContextListener, HttpSessionBindingListener
@@ -62,6 +64,9 @@ public class UISessionImpl
   private transient ISessionShutdownAdapter shutdownAdapter;
   private transient ApplicationContextImpl applicationContext;
 
+  private final TextSizeStorage textSizeStorage;
+  private final ProbeStore probeStore;
+
   public UISessionImpl( ApplicationContextImpl applicationContext, HttpSession httpSession ) {
     this( applicationContext, httpSession, null );
   }
@@ -80,6 +85,18 @@ public class UISessionImpl
     id = Integer.toHexString( hashCode() );
     bound = true;
     connection = new ConnectionImpl( this );
+
+    boolean textSizeStoreSessionScoped = RWTProperties.isTextSizeStoreSessionScoped();
+    textSizeStorage = textSizeStoreSessionScoped ? new TextSizeStorage() : null;
+    probeStore = textSizeStoreSessionScoped ? new ProbeStore( textSizeStorage ) : null;
+  }
+
+  public TextSizeStorage getTextSizeStorage() {
+    return textSizeStorage;
+  }
+
+  public ProbeStore getProbeStore() {
+    return probeStore;
   }
 
   public static UISessionImpl getInstanceFromSession( HttpSession httpSession, String connectionId )

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/ProbeStore.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/ProbeStore.java
@@ -10,13 +10,14 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal.textsize;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.swt.graphics.FontData;
 
 
-public class ProbeStore {
+public class ProbeStore implements Serializable {
   private final Map<FontData,Probe> probes;
   private final TextSizeStorage textSizeStorage;
 

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorage.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorage.java
@@ -26,13 +26,15 @@ import java.util.Set;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
 
+import org.eclipse.rap.rwt.internal.util.SerializableLock;
 
-public final class TextSizeStorage {
+
+public final class TextSizeStorage implements Serializable {
 
   public static final int MIN_STORE_SIZE = 1000;
   public static final int DEFAULT_STORE_SIZE = 10000;
 
-  private final Object lock;
+  private final SerializableLock lock;
   // access is guarded by 'lock'
   private final Set<FontData> fontDatas;
   // access is guarded by 'lock'
@@ -42,7 +44,7 @@ public final class TextSizeStorage {
   private long clock;
 
 
-  private static class Entry {
+  private static class Entry implements Serializable {
     private Point point;
     private long timeStamp;
   }
@@ -63,7 +65,7 @@ public final class TextSizeStorage {
 
 
   public TextSizeStorage() {
-    lock = new Object();
+    lock = new SerializableLock();
     data = new HashMap<>();
     fontDatas = new HashSet<>();
     setMaximumStoreSize( getTextSizeStoreSize( DEFAULT_STORE_SIZE ) );

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil.java
@@ -17,13 +17,17 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
 
+import org.eclipse.rap.rwt.RWT;
+import org.eclipse.rap.rwt.internal.RWTProperties;
+import org.eclipse.rap.rwt.internal.service.UISessionImpl;
+
 
 final class TextSizeStorageUtil {
 
   static Point lookup( FontData fontData, String string, int wrapWidth, int mode ) {
     Point result = null;
     if( ProbeResultStore.getInstance().containsProbeResult( fontData ) ) {
-      TextSizeStorage textSizeStorage = getApplicationContext().getTextSizeStorage();
+      TextSizeStorage textSizeStorage = getTextSizeStorage();
       Integer key = getKey( fontData, string, wrapWidth, mode );
       result = textSizeStorage.lookupTextSize( key );
       if( result == null && wrapWidth > 0 ) {
@@ -47,7 +51,7 @@ final class TextSizeStorageUtil {
   {
     checkFontExists( fontData );
     Integer key = getKey( fontData, string, wrapWidth, mode );
-    getApplicationContext().getTextSizeStorage().storeTextSize( key, measuredTextSize );
+    getTextSizeStorage().storeTextSize( key, measuredTextSize );
   }
 
   static Integer getKey( FontData fontData, String string, int wrapWidth, int mode ) {
@@ -65,6 +69,13 @@ final class TextSizeStorageUtil {
     return Integer.valueOf( hashCode );
   }
 
+  static TextSizeStorage getTextSizeStorage() {
+    TextSizeStorage storage = ( (UISessionImpl) RWT.getUISession() ).getTextSizeStorage();
+    if( storage == null ) {
+        storage = getApplicationContext().getTextSizeStorage();
+    }
+    return storage;
+  }
 
   private static void checkFontExists( FontData fontData ) {
     if( !ProbeResultStore.getInstance().containsProbeResult( fontData ) ) {

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/MeasurementOperator_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/MeasurementOperator_Test.java
@@ -23,6 +23,7 @@ import static org.eclipse.rap.rwt.internal.textsize.MeasurementUtil.getId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -45,6 +46,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.rap.rwt.internal.RWTProperties;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,6 +77,7 @@ public class MeasurementOperator_Test {
   @After
   public void tearDown() {
     Fixture.tearDown();
+    System.getProperties().remove( RWTProperties.TEXT_SIZE_STORE_SESSION_SCOPED );
   }
 
   @Test
@@ -203,6 +206,19 @@ public class MeasurementOperator_Test {
     operator.renderMeasurementItems();
 
     checkResponseContainsMeasurementCall();
+  }
+
+  @Test
+  public void testSeparateProbeStoresIfSessionScoped() {
+    ProbeStore pb1 = MeasurementUtil.getMeasurementOperator().getProbeStore();
+
+    System.setProperty( RWTProperties.TEXT_SIZE_STORE_SESSION_SCOPED , "true" );
+    Fixture.disposeOfServiceContext();
+    Fixture.createServiceContext();
+
+    ProbeStore pb2 = MeasurementUtil.getMeasurementOperator().getProbeStore();
+
+    assertNotEquals( pb1, pb2 );
   }
 
   private boolean probesContainFontData( FontData fontData ) {

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil_Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rap.rwt.internal.textsize;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -20,6 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.rap.rwt.testfixture.internal.Fixture;
+import org.eclipse.rap.rwt.internal.RWTProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
@@ -27,6 +29,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.eclipse.rap.rwt.RWT;
+import org.eclipse.rap.rwt.internal.service.UISessionImpl;
 
 public class TextSizeStorageUtil_Test {
 
@@ -42,6 +46,7 @@ public class TextSizeStorageUtil_Test {
   @After
   public void tearDown() {
     Fixture.tearDown();
+    System.getProperties().remove( RWTProperties.TEXT_SIZE_STORE_SESSION_SCOPED );
   }
 
   @Test
@@ -120,4 +125,20 @@ public class TextSizeStorageUtil_Test {
     }
   }
 
+  @Test
+  public void testSessionScopedStore() {
+    Point storedSize = new Point( 100, 10 );
+    ProbeResultStore.getInstance().createProbeResult( new Probe( FONT_DATA ), new Point( 2, 10 ) );
+    TextSizeStorageUtil.store( FONT_DATA, TEST_STRING, SWT.DEFAULT, MODE, storedSize );
+    Point lookupSize = TextSizeStorageUtil.lookup( FONT_DATA, TEST_STRING, SWT.DEFAULT, MODE );
+    assertEquals(storedSize, lookupSize);
+
+    System.setProperty( RWTProperties.TEXT_SIZE_STORE_SESSION_SCOPED , "true" );
+    Fixture.disposeOfServiceContext();
+    Fixture.createServiceContext();
+
+    ProbeResultStore.getInstance().createProbeResult( new Probe( FONT_DATA ), new Point( 2, 10 ) );
+    lookupSize = TextSizeStorageUtil.lookup( FONT_DATA, TEST_STRING, SWT.DEFAULT, MODE );
+    assertNull( lookupSize );
+  }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/eclipse-rap/org.eclipse.rap/pull/67

As requested I added two unit tests and removed the use of static fields to cache the property, as this led to issues when testing.