### PR TITLE
Add mode to make text-size-store UI session scoped

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/RWTProperties.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/RWTProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2022 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2024 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ public final class RWTProperties {
   public static final String SERVICE_HANDLER_USE_RELATIVE_URL = "org.eclipse.rap.rwt.serviceHandlerUseRelativeURL";
   public static final String DEVELOPMEMT_MODE = "org.eclipse.rap.rwt.developmentMode";
   public static final String TEXT_SIZE_STORE_SIZE = "org.eclipse.rap.rwt.textSizeStoreSize";
+  public static final String TEXT_SIZE_STORE_SESSION_SCOPED = "org.eclipse.rap.rwt.textSizeStoreSessionScoped";
   public static final String ENABLE_LOAD_TESTS = "org.eclipse.rap.rwt.enableLoadTests";
 
   /*
@@ -44,6 +45,10 @@ public final class RWTProperties {
 
   public static int getTextSizeStoreSize( int defaultValue ) {
     return getIntProperty( TEXT_SIZE_STORE_SIZE, defaultValue );
+  }
+
+  public static boolean isTextSizeStoreSessionScoped() {
+    return getBooleanProperty( TEXT_SIZE_STORE_SESSION_SCOPED, false );
   }
 
   public static boolean isLoadTestsEnabled() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/MeasurementOperator.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/MeasurementOperator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 Frank Appel and others.
+ * Copyright (c) 2011, 2024 Frank Appel and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,11 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal.textsize;
 
-import static org.eclipse.rap.rwt.internal.service.ContextProvider.getApplicationContext;
 import static org.eclipse.rap.rwt.internal.service.ContextProvider.getProtocolWriter;
 import static org.eclipse.rap.rwt.internal.textsize.MeasurementUtil.createItemParamObject;
 import static org.eclipse.rap.rwt.internal.textsize.MeasurementUtil.createProbeParamObject;
 import static org.eclipse.rap.rwt.internal.textsize.MeasurementUtil.getId;
+import static org.eclipse.rap.rwt.internal.textsize.TextSizeStorageUtil.getProbeStore;
 import static org.eclipse.rap.rwt.remote.JsonMapping.readPoint;
 
 import java.util.Arrays;
@@ -59,7 +59,7 @@ class MeasurementOperator implements SerializableCompatibility {
   }
 
   private void addStartupProbesToBuffer() {
-    Probe[] probeList = getApplicationContext().getProbeStore().getProbes();
+    Probe[] probeList = getProbeStore().getProbes();
     probes.addAll( Arrays.asList( probeList ) );
   }
 
@@ -72,9 +72,10 @@ class MeasurementOperator implements SerializableCompatibility {
   }
 
   void addProbeToMeasure( FontData fontData ) {
-    Probe probe = getApplicationContext().getProbeStore().getProbe( fontData );
+    ProbeStore probeStore = getProbeStore();
+    Probe probe = probeStore.getProbe( fontData );
     if( probe == null ) {
-      probe = getApplicationContext().getProbeStore().createProbe( fontData );
+      probe = probeStore.createProbe( fontData );
     }
     probes.add( probe );
   }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/ProbeStore.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/ProbeStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 EclipseSource and others.
+ * Copyright (c) 2011, 2024 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,14 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal.textsize;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.swt.graphics.FontData;
 
 
-public class ProbeStore {
+public class ProbeStore implements Serializable {
   private final Map<FontData,Probe> probes;
   private final TextSizeStorage textSizeStorage;
 

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorage.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2016 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2007, 2024 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,16 +23,17 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.rap.rwt.internal.util.SerializableLock;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
 
 
-public final class TextSizeStorage {
+public final class TextSizeStorage implements Serializable {
 
   public static final int MIN_STORE_SIZE = 1000;
   public static final int DEFAULT_STORE_SIZE = 10000;
 
-  private final Object lock;
+  private final SerializableLock lock;
   // access is guarded by 'lock'
   private final Set<FontData> fontDatas;
   // access is guarded by 'lock'
@@ -42,7 +43,7 @@ public final class TextSizeStorage {
   private long clock;
 
 
-  private static class Entry {
+  private static class Entry implements Serializable {
     private Point point;
     private long timeStamp;
   }
@@ -63,7 +64,7 @@ public final class TextSizeStorage {
 
 
   public TextSizeStorage() {
-    lock = new Object();
+    lock = new SerializableLock();
     data = new HashMap<>();
     fontDatas = new HashSet<>();
     setMaximumStoreSize( getTextSizeStoreSize( DEFAULT_STORE_SIZE ) );

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2014 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2007, 2024 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,8 @@ package org.eclipse.rap.rwt.internal.textsize;
 
 import static org.eclipse.rap.rwt.internal.service.ContextProvider.getApplicationContext;
 
+import org.eclipse.rap.rwt.RWT;
+import org.eclipse.rap.rwt.internal.service.UISessionImpl;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
@@ -23,7 +25,7 @@ final class TextSizeStorageUtil {
   static Point lookup( FontData fontData, String string, int wrapWidth, int mode ) {
     Point result = null;
     if( ProbeResultStore.getInstance().containsProbeResult( fontData ) ) {
-      TextSizeStorage textSizeStorage = getApplicationContext().getTextSizeStorage();
+      TextSizeStorage textSizeStorage = getTextSizeStorage();
       Integer key = getKey( fontData, string, wrapWidth, mode );
       result = textSizeStorage.lookupTextSize( key );
       if( result == null && wrapWidth > 0 ) {
@@ -47,7 +49,7 @@ final class TextSizeStorageUtil {
   {
     checkFontExists( fontData );
     Integer key = getKey( fontData, string, wrapWidth, mode );
-    getApplicationContext().getTextSizeStorage().storeTextSize( key, measuredTextSize );
+    getTextSizeStorage().storeTextSize( key, measuredTextSize );
   }
 
   static Integer getKey( FontData fontData, String string, int wrapWidth, int mode ) {
@@ -65,6 +67,21 @@ final class TextSizeStorageUtil {
     return Integer.valueOf( hashCode );
   }
 
+  static TextSizeStorage getTextSizeStorage() {
+    TextSizeStorage result = ( ( UISessionImpl ) RWT.getUISession() ).getTextSizeStorage();
+    if( result == null ) {
+      result = getApplicationContext().getTextSizeStorage();
+    }
+    return result;
+  }
+
+  static ProbeStore getProbeStore() {
+    ProbeStore result = ( ( UISessionImpl ) RWT.getUISession() ).getProbeStore();
+    if( result == null ) {
+      result = getApplicationContext().getProbeStore();
+    }
+    return result;
+  }
 
   private static void checkFontExists( FontData fontData ) {
     if( !ProbeResultStore.getInstance().containsProbeResult( fontData ) ) {

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/RWTProperties_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/RWTProperties_Test.java
@@ -12,6 +12,7 @@ package org.eclipse.rap.rwt.internal;
 
 import static org.eclipse.rap.rwt.internal.RWTProperties.ENABLE_LOAD_TESTS;
 import static org.eclipse.rap.rwt.internal.RWTProperties.SERVICE_HANDLER_BASE_URL;
+import static org.eclipse.rap.rwt.internal.RWTProperties.TEXT_SIZE_STORE_SESSION_SCOPED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -111,6 +112,15 @@ public class RWTProperties_Test {
     System.setProperty( ENABLE_LOAD_TESTS, "true" );
 
     assertTrue( RWTProperties.isLoadTestsEnabled() );
+  }
+
+  @Test
+  public void testIsTextSizeStoreSessionScoped() {
+    assertFalse( RWTProperties.isTextSizeStoreSessionScoped() );
+
+    System.setProperty( TEXT_SIZE_STORE_SESSION_SCOPED, "true" );
+
+    assertTrue( RWTProperties.isTextSizeStoreSessionScoped() );
   }
 
 }


### PR DESCRIPTION
Setting org.eclipse.rap.rwt.textSizeStoreSessionScoped=true allows to trade performance for correctness in environments where clients return inconsistent text measurements. By caching the text sizes in the UISession instead of the app context, measurements only have to be consistent within the same client. The downside of this approach is each client has to re-compute each text the first time it is measured.

Fix #22