### PR TITLE
Fix a memory leak when disposing the timer with not executed tasks

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/TimerExecScheduler.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/TimerExecScheduler.java
@@ -15,6 +15,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectInputValidation;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedList;
@@ -58,6 +59,8 @@ class TimerExecScheduler implements SerializableCompatibility {
 
   void dispose() {
     synchronized( display.getDeviceLock() ) {
+      Collection<TimerExecTask> tasksToCancel = new ArrayList<>( tasks );
+      tasksToCancel.forEach( task -> task.cancel() );
       if( timer != null ) {
         timer.cancel();
       }

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/TimerExecScheduler_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/TimerExecScheduler_Test.java
@@ -125,6 +125,7 @@ public class TimerExecScheduler_Test {
   public void testSerializationIsThreadSafe() throws Exception {
     scheduler = new TimerExecScheduler( display );
     Runnable runnable = new Runnable() {
+      @Override
       public void run() {
         try {
           scheduler.schedule( 1, new NoOpRunnable() );
@@ -141,6 +142,19 @@ public class TimerExecScheduler_Test {
     joinThreads( threads );
 
     assertEquals( 0, exceptions.size() );
+  }
+
+  @Test
+  public void testDispose_cancelsTimerAndTask() {
+    Runnable runnable = mock( Runnable.class );
+    scheduler.schedule( 23, runnable );
+
+    scheduler.dispose();
+
+    ArgumentCaptor<TimerExecTask> taskCaptor = ArgumentCaptor.forClass( TimerExecTask.class );
+    verify( timer ).schedule( taskCaptor.capture(), eq( 23L ) );
+    verify( timer ).cancel();
+    verify( taskCaptor.getValue() ).cancel();
   }
 
 }


### PR DESCRIPTION
To fix the issue cancel all not executed tasks during the TimerExecScheduler dispose.

Fix: #146