### PR TITLE
Fix randomly failing testInitStartupProbes test

### DIFF
--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/RWTProperties_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/RWTProperties_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 EclipseSource and others.
+ * Copyright (c) 2013, 2024 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ public class RWTProperties_Test {
     System.getProperties().remove( TEST_PROPERTY );
     System.getProperties().remove( SERVICE_HANDLER_BASE_URL );
     System.getProperties().remove( ENABLE_LOAD_TESTS );
+    System.getProperties().remove( TEXT_SIZE_STORE_SESSION_SCOPED );
   }
 
   @Test

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/MeasurementOperator_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/MeasurementOperator_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Frank Appel and others.
+ * Copyright (c) 2011, 2024 Frank Appel and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal.textsize;
 
+import static org.eclipse.rap.rwt.internal.RWTProperties.TEXT_SIZE_STORE_SESSION_SCOPED;
 import static org.eclipse.rap.rwt.internal.protocol.JsonUtil.createJsonArray;
 import static org.eclipse.rap.rwt.internal.protocol.RemoteObjectFactory.getRemoteObject;
 import static org.eclipse.rap.rwt.internal.service.ContextProvider.getApplicationContext;
@@ -49,7 +50,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class MeasurementOperator_Test {
 
   private static final FontData FONT_DATA_1 = new FontData( "arial", 12, SWT.NONE );
@@ -66,6 +66,7 @@ public class MeasurementOperator_Test {
 
   @Before
   public void setUp() {
+    System.clearProperty( TEXT_SIZE_STORE_SESSION_SCOPED );
     Fixture.setUp();
     display = new Display();
     operator = MeasurementUtil.getMeasurementOperator();

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/textsize/TextSizeStorageUtil_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 Frank Appel and others.
+ * Copyright (c) 2011, 2024 Frank Appel and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Ensure that TEXT_SIZE_STORE_SESSION_SCOPED is cleared before test execution.