### PR TITLE
Issue 179 scrolling continues unexpectedly

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/widgets/base/AbstractSlider.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/widgets/base/AbstractSlider.js
@@ -249,9 +249,14 @@ rwt.qx.Class.define( "rwt.widgets.base.AbstractSlider", {
     _onThumbMouseMove : function( event ) {
       event.stopPropagation();
       if( this._thumb.getCapture() ) {
-        var mousePos = this._getMouseOffset( event );
-        var newSelection = this._pxToVirtual( mousePos - this._thumbDragOffset );
-        this._setSelection( newSelection );
+		if( (event.getDomEvent().buttons & 0x01) === 0x01) ) {
+			var mousePos = this._getMouseOffset( event );
+			var newSelection = this._pxToVirtual( mousePos - this._thumbDragOffset );
+			this._setSelection( newSelection );
+		} else {
+			this._thumb.setCapture(false);
+			this._onMouseUp();
+		}
       }
     },
 


### PR DESCRIPTION
[Issue 179](https://github.com/eclipse-rap/org.eclipse.rap/issues/179)

added a check to AbstractSlider._onThumbMouseMove() whether the main mouse button is still pressed; if that is not the case then the scrolling operation is stopped. for this, the DOM event must be checked because MouseEvent.isLeftButtonPressed() does not work for mousemove.