### PR TITLE
Fix Grid getColumn calculation when row header is visible

### DIFF
--- a/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -670,6 +670,12 @@ public class Grid extends Composite {
     }
     GridColumn overThis = null;
     int x2 = 0;
+    if ( isRowHeaderVisible() ) {
+      if ( point.x <= rowHeadersColumn.getWidth() ) {
+        return null;
+      }
+      x2 += rowHeadersColumn.getWidth();
+    }
     x2 -= hScroll.getSelection();
     for( GridColumn column : displayOrderedColumns ) {
       if( !column.isVisible() ) {


### PR DESCRIPTION
For the Nebula Grid, when the row header is visible, the `getColumn` calculation didn't account for the additional width, and so the incorrect column was returned. The width is now added to the accumulator and so the correct column is always returned, even when clicking on the very edge of the column.

Matches Nebula's code here: https://github.com/eclipse/nebula/blob/master/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java#L1262-L1268.