### PR TITLE
Export all packages from org.eclipse.rap.nebula.jface.gridviewer

### DIFF
--- a/bundles/org.eclipse.rap.nebula.jface.gridviewer/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.nebula.jface.gridviewer/META-INF/MANIFEST.MF
@@ -8,4 +8,11 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.rap.nebula.widgets.grid;bundle-version="4.0.0",
  org.eclipse.rap.jface;bundle-version="[4.0.0,5.0.0)"
-Export-Package: org.eclipse.nebula.jface.gridviewer
+Export-Package: org.eclipse.nebula.jface.gridviewer;
+  uses:="org.eclipse.swt.events,
+   org.eclipse.swt.graphics,
+   org.eclipse.swt.widgets,
+   org.eclipse.nebula.widgets.grid,
+   org.eclipse.jface.layout,
+   org.eclipse.jface.viewers",
+ org.eclipse.nebula.jface.gridviewer.internal;x-internal:=true


### PR DESCRIPTION
Makes sure all packages (for now, just a single internal one) is exported from `org.eclipse.rap.nebula.jface.gridviewer`. Marked as `x-internal` so clients receive warnings when importing them. See upstream Nebula here: https://github.com/eclipse/nebula/blob/master/widgets/grid/org.eclipse.nebula.widgets.grid/META-INF/MANIFEST.MF#L10 (they combined the gridviewer bundle into the grid bundle but the package name is the same).