### PR TITLE
Rename extension point

### DIFF
--- a/bundles/org.eclipse.rap.ui/plugin.xml
+++ b/bundles/org.eclipse.rap.ui/plugin.xml
@@ -2372,7 +2372,7 @@
            uses the context already on startup
    -->
    <extension
-        point="org.eclipse.equinox.http.registry.httpcontexts">
+        point="org.eclipse.rap.http.registry.httpcontexts">
      <httpcontext
            class="org.eclipse.rap.ui.internal.RAPHttpContext"
            id="org.eclipse.rap.httpcontext">


### PR DESCRIPTION
The "org.eclipse.equinox.http.registry.httpcontexts" extension point is renamed to "org.eclipse.rap.http.registry.httpcontexts" as part of bundle rename.