### PR TITLE
Provide workaround for E4 javax.servlet dependencies

### DIFF
--- a/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
@@ -34,14 +34,28 @@
          id="jakarta.servlet-api"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="4.0.0"
          unpack="false"/>
 
    <plugin
          id="jakarta.servlet-api.source"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="4.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="jakarta.servlet-api"
+         download-size="0"
+         install-size="0"
+         version="6.1.0"
+         unpack="false"/>
+
+   <plugin
+         id="jakarta.servlet-api.source"
+         download-size="0"
+         install-size="0"
+         version="6.1.0"
          unpack="false"/>
 
    <plugin


### PR DESCRIPTION
The bundle org.eclipse.e4.emf.xpath has a dependency to the external bundle org.apache.commomns.jxpath which is not developed any more. This bundle itself has dependencies to various Java packages from the javax.servlet.* namespace.

As a short term solution, provide the javax.servlet API by adding the Jakarta servlet 4.0 bundle in addition to the 6.1 version temporarily to the E4 Equinox feature in order to satisfy the runtime only constraint.