### PR TITLE
Releng/update jakarta build

### DIFF
--- a/bundles/org.eclipse.e4.emf.xpath/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.e4.emf.xpath/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013 IBM Corporation and others.
+# Copyright (c) 2013, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.e4.emf.xpath/about.html
+++ b/bundles/org.eclipse.e4.emf.xpath/about.html
@@ -32,5 +32,29 @@
 			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
 	</p>
 
+	<h3>Third Party Content</h3>
+	<p>
+		The Content includes items that have been sourced from third parties as set out below. If you
+		did not receive this Content directly from the Eclipse Foundation, the following is provided
+		for informational purposes only, and you should look to the Redistributor's license for
+		terms and conditions of use.
+	</p>
+
+	<h4>Apache Commons JXPath 1.3 (subset)</h4>
+
+	<p>
+  		The plug-in includes code from the Apache Commons JXPath library, version 1.3
+		(&quot;commons-jxpath&quot;) developed by the Apache Software Foundation as part of the
+		Apache Commons project. Your use of this code is subject to the terms and conditions of the
+		Apache License, Version 2.0 (&quot;Apache License&quot;). A copy of the Apache License can be found
+		in <a href="about_files/LICENSE-2.0.txt">LICENSE-2.0.txt</a> and is also available at
+  		<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+	</p>
+
+	<p>
+  		The Apache attribution <a href="about_files/NOTICE">NOTICE</a> file is
+  		included with the Content in accordance with 4d of the Apache License.
+	</p>
+
 </body>
 </html>

--- a/bundles/org.eclipse.e4.emf.xpath/build.properties
+++ b/bundles/org.eclipse.e4.emf.xpath/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013 IBM Corporation and others.
+# Copyright (c) 2013, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.e4.emf.xpath/pom.xml
+++ b/bundles/org.eclipse.e4.emf.xpath/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>org.eclipse.e4.emf.xpath</artifactId>
+  <version>0.4.300-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <parent>
+    <groupId>org.eclipse.rap</groupId>
+    <artifactId>org.eclipse.rap.runtime-parent</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+    <relativePath>../../releng/org.eclipse.rap.build/pom.xml</relativePath>
+  </parent>
+
+  <build>
+    <resources>
+      <!-- to ensure that the feature lookup of the ui test works -->
+      <resource>
+        <directory>.</directory>
+        <includes>
+          <include>META-INF/</include>
+        </includes>
+      </resource>
+    </resources>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-source-plugin</artifactId>
+      </plugin>
+
+      <!-- Configure qualifier replacement prepended by 'rap-' -->
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <archiveSite>true</archiveSite>
+          <format>'rap-'yyyyMMdd-HHmm</format>
+        </configuration>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
@@ -863,20 +863,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.jxpath"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.jxpath.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.e4.core.contexts"
          download-size="0"
          install-size="0"

--- a/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.equinox.target.feature/feature.xml
@@ -24,27 +24,6 @@
    </requires>
 
    <plugin
-         id="javax.el-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="jakarta.servlet-api"
-         download-size="0"
-         install-size="0"
-         version="4.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="jakarta.servlet-api.source"
-         download-size="0"
-         install-size="0"
-         version="4.0.0"
-         unpack="false"/>
-
-   <plugin
          id="jakarta.servlet-api"
          download-size="0"
          install-size="0"
@@ -758,20 +737,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.jetty.ee8.servlet"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.ee8.servlet.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.jetty.util"
          download-size="0"
          install-size="0"
@@ -808,20 +773,6 @@
 
    <plugin
          id="org.hamcrest.core.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.commons-fileupload2-jakarta-servlet5"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.commons-fileupload2-javax"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.eclipse.rap.equinox.target.feature/feature.xml
+++ b/features/org.eclipse.rap.equinox.target.feature/feature.xml
@@ -27,14 +27,14 @@
          id="jakarta.servlet-api"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="6.1.0"
          unpack="false"/>
 
    <plugin
          id="jakarta.servlet-api.source"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="6.1.0"
          unpack="false"/>
 
    <plugin
@@ -723,20 +723,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.jetty.ee8.servlet"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.ee8.servlet.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.jetty.util"
          download-size="0"
          install-size="0"
@@ -773,20 +759,6 @@
 
    <plugin
          id="org.hamcrest.core.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.commons-fileupload2-jakarta-servlet5"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.commons-fileupload2-javax"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>bundles/org.eclipse.rap.http.servletbridge</module>
     <module>bundles/org.eclipse.rap.servletbridge</module>
     <module>bundles/org.eclipse.e4.core.commands</module>
+    <module>bundles/org.eclipse.e4.emf.xpath</module>
     <module>bundles/org.eclipse.e4.ui.bindings</module>
     <module>bundles/org.eclipse.e4.ui.workbench.addons.swt</module>
     <module>bundles/org.eclipse.e4.ui.workbench.renderers.swt</module>


### PR DESCRIPTION
- Include the forked new bundle `org.eclipse.e4.emf.xpath` in the build, and add the required build configuration and license files.
- Update the E3 and E4 target features, and remove all outdated bundles referencing javax.servlet namesspace, or implementing anything that is not Jakarta Servlet 6 specific.