### PR TITLE
RAP4 Java Servlet 6 update for example projects

### DIFF
--- a/examples/org.eclipse.rap.examples/src/org/eclipse/rap/examples/internal/MainUi.java
+++ b/examples/org.eclipse.rap.examples/src/org/eclipse/rap/examples/internal/MainUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 EclipseSource and others.
+ * Copyright (c) 2011, 2024 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,7 +47,7 @@ public class MainUi extends AbstractEntryPoint {
 
   private final static String SHELL_RESIZE_NEEDED = "shellResizeNeeded";
 
-  private static final String RAP_PAGE_URL = "http://eclipse.org/rap/";
+  private static final String RAP_PAGE_URL = "https://eclipse.dev/rap/";
   private static final int HEADER_HEIGHT = 140;
   private static final int CENTER_AREA_WIDTH = 998;
 

--- a/examples/org.eclipse.rap.nebula.widgets.grid.demo.examples/src/org/eclipse/rap/nebula/widget/grid/demo/examples/NebulaGridExamplePage.java
+++ b/examples/org.eclipse.rap.nebula.widgets.grid.demo.examples/src/org/eclipse/rap/nebula/widget/grid/demo/examples/NebulaGridExamplePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 EclipseSource and others.
+ * Copyright (c) 2013, 2024 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public class NebulaGridExamplePage implements IExamplePage {
   private static final int NO_DATA = Integer.MIN_VALUE;
   private static final String EURO = "€ ";
   private static final String[] YEARS = new String[] {
-    "2016", "2017", "2018", "2019", "2020"
+    "2019", "2020", "2021", "2022", "2023"
   };
 
   private List<CompanyData> data;
@@ -65,7 +65,7 @@ public class NebulaGridExamplePage implements IExamplePage {
                                6138560, 10604917, 16593986, 21795550, 23650563 ) );
     data.add( new CompanyData( "Costs and expenses:",
                                NO_DATA, NO_DATA, NO_DATA, NO_DATA, NO_DATA ) );
-    data.add( new CompanyData( "Costs of ravenues",
+    data.add( new CompanyData( "Costs of revenues",
                                2577088, 4225027, 6649085, 8621506, 8844115 ) );
     data.add( new CompanyData( "Research and development",
                                599510, 1228589, 2119985, 2793192, 2843027 ) );

--- a/releng/org.eclipse.rap.examples.build/controlsdemo/assembly.xml
+++ b/releng/org.eclipse.rap.examples.build/controlsdemo/assembly.xml
@@ -9,7 +9,6 @@
       <directory>${basedir}/target/products/${artifactId}/linux/gtk/x86_64</directory>
       <outputDirectory>/WEB-INF</outputDirectory>
       <excludes>
-        <exclude>plugins/javax.servlet*.jar</exclude>
         <exclude>plugins/jakarta.servlet-api*.jar</exclude>
       </excludes>
     </fileSet>
@@ -21,7 +20,7 @@
       <directory>${basedir}/target/products/${artifactId}/linux/gtk/x86_64/plugins</directory>
       <outputDirectory>/WEB-INF/lib</outputDirectory>
       <includes>
-        <include>org.eclipse.equinox.servletbridge_*.jar</include>
+        <include>org.eclipse.rap.servletbridge_*.jar</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/releng/org.eclipse.rap.examples.build/controlsdemo/org.eclipse.rap.examples.controls.product
+++ b/releng/org.eclipse.rap.examples.build/controlsdemo/org.eclipse.rap.examples.controls.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="RAP Examples Controls Demo Product" uid="org.eclipse.rap.examples.controlsdemo.product" version="3.5.0.qualifier" useFeatures="false" includeLaunchers="false">
+<product name="RAP Examples Controls Demo Product" uid="org.eclipse.rap.examples.controlsdemo.product" version="4.0.0.qualifier" useFeatures="false" includeLaunchers="false">
 
    <configIni use="default">
    </configIni>
@@ -27,15 +27,14 @@
       <plugin id="org.eclipse.equinox.app"/>
       <plugin id="org.eclipse.equinox.common"/>
       <plugin id="org.eclipse.equinox.console"/>
-      <plugin id="org.eclipse.equinox.http.registry"/>
-      <plugin id="org.eclipse.equinox.http.servlet"/>
-      <plugin id="org.eclipse.equinox.http.servletbridge"/>
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
       <plugin id="org.eclipse.osgi"/>
-      <plugin id="org.eclipse.osgi.services"/>
       <plugin id="org.eclipse.osgi.util"/>
       <plugin id="org.eclipse.rap.demo.controls"/>
+      <plugin id="org.eclipse.rap.http.registry"/>
+      <plugin id="org.eclipse.rap.http.servlet"/>
+      <plugin id="org.eclipse.rap.http.servletbridge"/>
       <plugin id="org.eclipse.rap.jface"/>
       <plugin id="org.eclipse.rap.jface.databinding"/>
       <plugin id="org.eclipse.rap.nebula.widgets.grid"/>
@@ -47,10 +46,9 @@
    <configurations>
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.equinox.http.registry" autoStart="true" startLevel="0" />
-      <plugin id="org.eclipse.equinox.http.servletbridge" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.osgi.services" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.rap.demo.controls" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.rap.http.registry" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.rap.http.servletbridge" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.rap.rwt" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.rap.rwt.osgi" autoStart="true" startLevel="0" />
    </configurations>

--- a/releng/org.eclipse.rap.examples.build/controlsdemo/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/controlsdemo/pom.xml
@@ -48,7 +48,6 @@
         </executions>
       </plugin>
 
-      <!-- Remove servlet spec (old javax.servlet, new o.e.jetty.servlet-api) from the bundles.info -->
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>maven-replacer-plugin</artifactId>
@@ -66,11 +65,7 @@
           <replacements>
             <replacement>
               <token>osgi.bundles=</token>
-              <value>osgi.bundles=org.eclipse.equinox.servletbridge.extensionbundle,</value>
-            </replacement>
-            <replacement>
-              <token>reference\\:file\\:javax.servlet.*?jar@4,</token>
-              <value></value>
+              <value>osgi.bundles=org.eclipse.rap.servletbridge.extensionbundle,</value>
             </replacement>
             <replacement>
               <token>reference\\:file\\:jakarta.servlet-api.*?jar@4,</token>

--- a/releng/org.eclipse.rap.examples.build/controlsdemo/rootfiles/WEB-INF/web.xml
+++ b/releng/org.eclipse.rap.examples.build/controlsdemo/rootfiles/WEB-INF/web.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.2//EN" "http://java.sun.com/j2ee/dtds/web-app_2_2.dtd">
 <web-app id="WebApp">
   <servlet id="bridge">
-    <servlet-name>equinoxbridgeservlet</servlet-name>
-    <display-name>Equinox Bridge Servlet</display-name>
-    <description>Equinox Bridge Servlet</description>
-    <servlet-class>org.eclipse.equinox.servletbridge.BridgeServlet</servlet-class>
+    <servlet-name>rapbridgeservlet</servlet-name>
+    <display-name>RAP Bridge Servlet</display-name>
+    <description>RAP Bridge Servlet</description>
+    <servlet-class>org.eclipse.rap.servletbridge.BridgeServlet</servlet-class>
 
     <init-param>
       <param-name>commandline</param-name>
@@ -20,7 +20,7 @@
     <!--
       When the framework is deployed, an extension bundle must be present to allow the Servlet API to
       be exported by the container.  Typically, this extension bundle is created at deploy time by the
-      FrameworkLauncher.  If, however, an extension bundle (with id 'org.eclipse.equinox.servletbridge.extensionbundle') is
+      FrameworkLauncher.  If, however, an extension bundle (with id 'org.eclipse.rap.servletbridge.extensionbundle') is
       already present in the 'plugins' area, then preference is given to the existing bundle.
       If this param is set to 'true', then the existing extension bundle with be *overridden* and
       the one created by the FrameworkLauncher will replace any existing one.  The default is 'false'
@@ -37,7 +37,7 @@
   </servlet>
 
   <servlet-mapping>
-    <servlet-name>equinoxbridgeservlet</servlet-name>
+    <servlet-name>rapbridgeservlet</servlet-name>
     <url-pattern>/*</url-pattern>
   </servlet-mapping>
 

--- a/releng/org.eclipse.rap.examples.build/parent/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/parent/pom.xml
@@ -35,10 +35,10 @@
           <filters>
             <filter>
               <type>java-package</type>
-              <id>javax.servlet</id>
+              <id>jakarta.servlet</id>
               <restrictTo>
                 <type>eclipse-plugin</type>
-                <id>javax.servlet</id>
+                <id>jakarta.servlet</id>
               </restrictTo>
             </filter>
           </filters>

--- a/releng/org.eclipse.rap.examples.build/rapdemo/assembly.xml
+++ b/releng/org.eclipse.rap.examples.build/rapdemo/assembly.xml
@@ -9,7 +9,6 @@
       <directory>${basedir}/target/products/${artifactId}/linux/gtk/x86_64</directory>
       <outputDirectory>/WEB-INF</outputDirectory>
       <excludes>
-        <exclude>plugins/javax.servlet*.jar</exclude>
         <exclude>plugins/jakarta.servlet-api*.jar</exclude>
       </excludes>
     </fileSet>
@@ -21,7 +20,7 @@
       <directory>${basedir}/target/products/${artifactId}/linux/gtk/x86_64/plugins</directory>
       <outputDirectory>/WEB-INF/lib</outputDirectory>
       <includes>
-        <include>org.eclipse.equinox.servletbridge_*.jar</include>
+        <include>org.eclipse.rap.servletbridge_*.jar</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/releng/org.eclipse.rap.examples.build/rapdemo/org.eclipse.rap.examples.rapdemo.product
+++ b/releng/org.eclipse.rap.examples.build/rapdemo/org.eclipse.rap.examples.rapdemo.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="RAP Examples Demo Product" uid="org.eclipse.rap.examples.rapdemo.product" version="3.5.0.qualifier" useFeatures="false" includeLaunchers="false">
+<product name="RAP Examples Demo Product" uid="org.eclipse.rap.examples.rapdemo.product" version="4.0.0.qualifier" useFeatures="false" includeLaunchers="false">
 
    <configIni use="default">
    </configIni>
@@ -11,7 +11,8 @@
 
    <plugins>
       <plugin id="com.ibm.icu"/>
-      <plugin id="org.apache.commons.commons-fileupload"/>
+      <plugin id="org.apache.commons.commons-fileupload2-core"/>
+      <plugin id="org.apache.commons.commons-fileupload2-jakarta-servlet6"/>
       <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.felix.gogo.command"/>
       <plugin id="org.apache.felix.gogo.runtime"/>
@@ -29,21 +30,22 @@
       <plugin id="org.eclipse.equinox.app"/>
       <plugin id="org.eclipse.equinox.common"/>
       <plugin id="org.eclipse.equinox.console"/>
-      <plugin id="org.eclipse.equinox.http.registry"/>
-      <plugin id="org.eclipse.equinox.http.servlet"/>
-      <plugin id="org.eclipse.equinox.http.servletbridge"/>
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
       <plugin id="org.eclipse.osgi"/>
-      <plugin id="org.eclipse.osgi.services"/>
       <plugin id="org.eclipse.osgi.util"/>
+      <!-- incompatible to RAP 4.0
       <plugin id="org.eclipse.rap.addons.autosuggest"/>
       <plugin id="org.eclipse.rap.addons.dropdown.demo.examples"/>
+      -->
       <plugin id="org.eclipse.rap.examples"/>
       <plugin id="org.eclipse.rap.examples.pages"/>
       <plugin id="org.eclipse.rap.filedialog"/>
       <plugin id="org.eclipse.rap.filedialog.demo.examples"/>
       <plugin id="org.eclipse.rap.fileupload"/>
+      <plugin id="org.eclipse.rap.http.registry"/>
+      <plugin id="org.eclipse.rap.http.servlet"/>
+      <plugin id="org.eclipse.rap.http.servletbridge"/>
       <plugin id="org.eclipse.rap.jface"/>
       <plugin id="org.eclipse.rap.jface.databinding"/>
       <plugin id="org.eclipse.rap.nebula.widgets.grid"/>
@@ -62,17 +64,17 @@
    <configurations>
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.equinox.http.registry" autoStart="true" startLevel="0" />
-      <plugin id="org.eclipse.equinox.http.servletbridge" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.osgi.services" autoStart="true" startLevel="1" />
+<!-- external and/or incompatible bundles
       <plugin id="org.eclipse.rap.addons.dropdown.demo.examples" autoStart="true" startLevel="0" />
-<!-- external bundles
       <plugin id="org.eclipse.rap.demo.enrondata" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.rap.demo.gmaps" autoStart="true" startLevel="0" />
 -->
       <plugin id="org.eclipse.rap.examples" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.rap.examples.pages" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.rap.filedialog.demo.examples" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.rap.http.registry" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.rap.http.servlet" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.rap.http.servletbridge" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.rap.nebula.widgets.grid.demo.examples" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.rap.nebula.widgets.richtext.demo.examples" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.rap.rwt" autoStart="true" startLevel="0" />

--- a/releng/org.eclipse.rap.examples.build/rapdemo/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/rapdemo/pom.xml
@@ -48,7 +48,6 @@
         </executions>
       </plugin>
 
-      <!-- Remove servlet spec (old javax.servlet, new o.e.jetty.servlet-api) from the bundles.info -->
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>maven-replacer-plugin</artifactId>
@@ -66,11 +65,7 @@
           <replacements>
             <replacement>
               <token>osgi.bundles=</token>
-              <value>osgi.bundles=org.eclipse.equinox.servletbridge.extensionbundle,</value>
-            </replacement>
-            <replacement>
-              <token>reference\\:file\\:javax.servlet.*?jar@4,</token>
-              <value></value>
+              <value>osgi.bundles=org.eclipse.rap.servletbridge.extensionbundle,</value>
             </replacement>
             <replacement>
               <token>reference\\:file\\:jakarta.servlet-api.*?jar@4,</token>

--- a/releng/org.eclipse.rap.examples.build/rapdemo/rootfiles/WEB-INF/web.xml
+++ b/releng/org.eclipse.rap.examples.build/rapdemo/rootfiles/WEB-INF/web.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.2//EN" "http://java.sun.com/j2ee/dtds/web-app_2_2.dtd">
 <web-app id="WebApp">
   <servlet id="bridge">
-    <servlet-name>equinoxbridgeservlet</servlet-name>
-    <display-name>Equinox Bridge Servlet</display-name>
-    <description>Equinox Bridge Servlet</description>
-    <servlet-class>org.eclipse.equinox.servletbridge.BridgeServlet</servlet-class>
+    <servlet-name>rapbridgeservlet</servlet-name>
+    <display-name>RAP Bridge Servlet</display-name>
+    <description>RAP Bridge Servlet</description>
+    <servlet-class>org.eclipse.rap.servletbridge.BridgeServlet</servlet-class>
 
     <init-param>
       <param-name>commandline</param-name>
@@ -20,7 +20,7 @@
     <!--
       When the framework is deployed, an extension bundle must be present to allow the Servlet API to
       be exported by the container.  Typically, this extension bundle is created at deploy time by the
-      FrameworkLauncher.  If, however, an extension bundle (with id 'org.eclipse.equinox.servletbridge.extensionbundle') is
+      FrameworkLauncher.  If, however, an extension bundle (with id 'org.eclipse.rap.servletbridge.extensionbundle') is
       already present in the 'plugins' area, then preference is given to the existing bundle.
       If this param is set to 'true', then the existing extension bundle with be *overridden* and
       the one created by the FrameworkLauncher will replace any existing one.  The default is 'false'
@@ -37,7 +37,7 @@
   </servlet>
 
   <servlet-mapping>
-    <servlet-name>equinoxbridgeservlet</servlet-name>
+    <servlet-name>rapbridgeservlet</servlet-name>
     <url-pattern>/*</url-pattern>
   </servlet-mapping>
 

--- a/releng/org.eclipse.rap.examples.build/workbenchdemo/assembly.xml
+++ b/releng/org.eclipse.rap.examples.build/workbenchdemo/assembly.xml
@@ -9,7 +9,6 @@
       <directory>${basedir}/target/products/${artifactId}/linux/gtk/x86_64</directory>
       <outputDirectory>/WEB-INF</outputDirectory>
       <excludes>
-        <exclude>plugins/javax.servlet*.jar</exclude>
         <exclude>plugins/jakarta.servlet-api*.jar</exclude>
       </excludes>
     </fileSet>
@@ -21,7 +20,7 @@
       <directory>${basedir}/target/products/${artifactId}/linux/gtk/x86_64/plugins</directory>
       <outputDirectory>/WEB-INF/lib</outputDirectory>
       <includes>
-        <include>org.eclipse.equinox.servletbridge_*.jar</include>
+        <include>org.eclipse.rap.servletbridge_*.jar</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/releng/org.eclipse.rap.examples.build/workbenchdemo/org.eclipse.rap.examples.workbench.product
+++ b/releng/org.eclipse.rap.examples.build/workbenchdemo/org.eclipse.rap.examples.workbench.product
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="RAP Examples Workbench Demo Product" uid="org.eclipse.rap.examples.workbenchdemo.product" version="3.5.0.qualifier" useFeatures="false" includeLaunchers="false">
+<product name="RAP Examples Workbench Demo Product" uid="org.eclipse.rap.examples.workbenchdemo.product" version="4.0.0.qualifier" type="bundles" includeLaunchers="false" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
 
    <launcherArgs>
    </launcherArgs>
+
+   <launcher>
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+
+   <vm>
+   </vm>
 
    <plugins>
       <plugin id="com.ibm.icu"/>
@@ -27,16 +36,15 @@
       <plugin id="org.eclipse.equinox.app"/>
       <plugin id="org.eclipse.equinox.common"/>
       <plugin id="org.eclipse.equinox.console"/>
-      <plugin id="org.eclipse.equinox.http.registry"/>
-      <plugin id="org.eclipse.equinox.http.servlet"/>
-      <plugin id="org.eclipse.equinox.http.servletbridge"/>
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
       <plugin id="org.eclipse.osgi"/>
-      <plugin id="org.eclipse.osgi.services"/>
       <plugin id="org.eclipse.osgi.util"/>
       <plugin id="org.eclipse.rap.demo"/>
       <plugin id="org.eclipse.rap.design.example"/>
+      <plugin id="org.eclipse.rap.http.registry"/>
+      <plugin id="org.eclipse.rap.http.servlet"/>
+      <plugin id="org.eclipse.rap.http.servletbridge"/>
       <plugin id="org.eclipse.rap.jface"/>
       <plugin id="org.eclipse.rap.jface.databinding"/>
       <plugin id="org.eclipse.rap.rwt"/>
@@ -48,14 +56,14 @@
    </plugins>
 
    <configurations>
-      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.equinox.http.registry" autoStart="true" startLevel="0" />
-      <plugin id="org.eclipse.equinox.http.servletbridge" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.osgi.services" autoStart="true" startLevel="1" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.rap.demo" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.rap.http.registry" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.rap.http.servletbridge" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.rap.rwt" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.rap.rwt.osgi" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.rap.ui" autoStart="true" startLevel="0" />
    </configurations>
 
 </product>

--- a/releng/org.eclipse.rap.examples.build/workbenchdemo/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/workbenchdemo/pom.xml
@@ -48,7 +48,6 @@
         </executions>
       </plugin>
 
-      <!-- Remove servlet spec (old javax.servlet, new o.e.jetty.servlet-api) from the bundles.info -->
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>maven-replacer-plugin</artifactId>
@@ -66,11 +65,7 @@
           <replacements>
             <replacement>
               <token>osgi.bundles=</token>
-              <value>osgi.bundles=org.eclipse.equinox.servletbridge.extensionbundle,</value>
-            </replacement>
-            <replacement>
-              <token>reference\\:file\\:javax.servlet.*?jar@4,</token>
-              <value></value>
+              <value>osgi.bundles=org.eclipse.rap.servletbridge.extensionbundle,</value>
             </replacement>
             <replacement>
               <token>reference\\:file\\:jakarta.servlet-api.*?jar@4,</token>

--- a/releng/org.eclipse.rap.examples.build/workbenchdemo/rootfiles/WEB-INF/web.xml
+++ b/releng/org.eclipse.rap.examples.build/workbenchdemo/rootfiles/WEB-INF/web.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.2//EN" "http://java.sun.com/j2ee/dtds/web-app_2_2.dtd">
 <web-app id="WebApp">
   <servlet id="bridge">
-    <servlet-name>equinoxbridgeservlet</servlet-name>
-    <display-name>Equinox Bridge Servlet</display-name>
-    <description>Equinox Bridge Servlet</description>
-    <servlet-class>org.eclipse.equinox.servletbridge.BridgeServlet</servlet-class>
+    <servlet-name>rapbridgeservlet</servlet-name>
+    <display-name>RAP Bridge Servlet</display-name>
+    <description>RAP Bridge Servlet</description>
+    <servlet-class>org.eclipse.rap.servletbridge.BridgeServlet</servlet-class>
 
     <init-param>
       <param-name>commandline</param-name>
@@ -20,7 +20,7 @@
     <!--
       When the framework is deployed, an extension bundle must be present to allow the Servlet API to
       be exported by the container.  Typically, this extension bundle is created at deploy time by the
-      FrameworkLauncher.  If, however, an extension bundle (with id 'org.eclipse.equinox.servletbridge.extensionbundle') is
+      FrameworkLauncher.  If, however, an extension bundle (with id 'org.eclipse.rap.servletbridge.extensionbundle') is
       already present in the 'plugins' area, then preference is given to the existing bundle.
       If this param is set to 'true', then the existing extension bundle with be *overridden* and
       the one created by the FrameworkLauncher will replace any existing one.  The default is 'false'
@@ -37,7 +37,7 @@
   </servlet>
 
   <servlet-mapping>
-    <servlet-name>equinoxbridgeservlet</servlet-name>
+    <servlet-name>rapbridgeservlet</servlet-name>
     <url-pattern>/*</url-pattern>
   </servlet-mapping>
 


### PR DESCRIPTION
Provide the required updates to make our three examplary .war products build.  

This includes the required changes in the extension bundle for Jakarta Servlet 6, but also the changes required to assemble the .war files, especially the change of dependencies and bundles in the product definitions.

This PR is meant to merged to the main branch as single commits, i.e. not to be squashed into one.