### PR TITLE
Fix selection event index in Nebula Grid

### DIFF
--- a/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/internal/gridkit/GridOperationHandler.java
+++ b/bundles/org.eclipse.rap.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/internal/gridkit/GridOperationHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 EclipseSource and others.
+ * Copyright (c) 2013, 2024 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -225,7 +225,7 @@ public class GridOperationHandler extends ControlOperationHandler<Grid> {
     if( item != null ) {
       Event event = createSelectionEvent( SWT.Selection, properties );
       event.item = item;
-      event.index = readIndex( properties );
+      event.index = readIndex( properties ) - getColumnOffset( grid );
       grid.notifyListeners( SWT.Selection, event );
     }
   }

--- a/tests/org.eclipse.rap.nebula.widgets.grid.test/src/org/eclipse/nebula/widgets/grid/internal/gridkit/GridOperationHandler_Test.java
+++ b/tests/org.eclipse.rap.nebula.widgets.grid.test/src/org/eclipse/nebula/widgets/grid/internal/gridkit/GridOperationHandler_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 EclipseSource and others.
+ * Copyright (c) 2013, 2024 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -256,6 +256,7 @@ public class GridOperationHandler_Test {
 
   @Test
   public void testHandleNotifySelection_withDetail_check() {
+    int dataCellIndex = 3;
     Grid spyGrid = spy( grid );
     handler = new GridOperationHandler( spyGrid );
     GridItem item = new GridItem( spyGrid, SWT.NONE );
@@ -263,7 +264,7 @@ public class GridOperationHandler_Test {
     JsonObject properties = new JsonObject()
       .add( "item", getId( item ) )
       .add( "detail", "check" )
-      .add( "index", 3 );
+      .add( "index", dataCellIndex );
     handler.handleNotify( EVENT_SELECTION, properties );
 
     ArgumentCaptor<Event> captor = ArgumentCaptor.forClass( Event.class );
@@ -271,7 +272,7 @@ public class GridOperationHandler_Test {
     Event event = captor.getValue();
     assertEquals( item, event.item );
     assertEquals( SWT.CHECK, event.detail );
-    assertEquals( 3, event.index );
+    assertEquals( dataCellIndex - 1, event.index );
   }
 
   @Test


### PR DESCRIPTION
The selection event index property was always greater by 1 because of the row header column.

Issue: https://github.com/eclipse-rap/org.eclipse.rap/issues/218