### PR TITLE
Explicitly set request encoding before reading request parameters

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/StartupJson.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/StartupJson.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 EclipseSource and others.
+ * Copyright (c) 2012, 2024 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.eclipse.rap.json.JsonObject;
 import org.eclipse.rap.json.JsonValue;
 import org.eclipse.rap.rwt.internal.protocol.ProtocolMessageWriter;
@@ -30,6 +28,9 @@ import org.eclipse.rap.rwt.internal.textsize.MeasurementUtil;
 import org.eclipse.rap.rwt.internal.theme.Theme;
 import org.eclipse.rap.rwt.internal.theme.ThemeManager;
 import org.eclipse.rap.rwt.internal.util.HTTP;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 
 public class StartupJson {
@@ -77,8 +78,14 @@ public class StartupJson {
 
   private static String getStartupParameters() {
     List<String> parameters = new ArrayList<>();
-    Map<String, String[]> parameterMap = getRequest().getParameterMap();
     try {
+      /*
+       * For POST request we can set the character encoding and get the properly decoded
+       * parameters via HttpServletRequest.getParameterMap API.
+       */
+      HttpServletRequest request = getRequest();
+      request.setCharacterEncoding( HTTP.CHARSET_UTF_8 );
+      Map<String, String[]> parameterMap = request.getParameterMap();
       for ( String name : parameterMap.keySet() ) {
         for( String value : parameterMap.get( name ) ) {
           String encName = encode( name, HTTP.CHARSET_UTF_8 );


### PR DESCRIPTION
When using startup POST request in Tomcat, the encoding of the parameters is broken. We need to set the encoding explicitly. The issue is not reproducible in Jetty.