### PR TITLE
Use correct extension point names in Java code

### DIFF
--- a/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/FilterManager.java
+++ b/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/FilterManager.java
@@ -24,7 +24,7 @@ import org.osgi.framework.*;
 
 public class FilterManager implements ExtensionPointTracker.Listener {
 
-	private static final String FILTERS_EXTENSION_POINT = "org.eclipse.equinox.http.registry.filters"; //$NON-NLS-1$
+	private static final String FILTERS_EXTENSION_POINT = "org.eclipse.rap.http.registry.filters"; //$NON-NLS-1$
 
 	private static final String HTTPCONTEXT_NAME = "httpcontext-name"; //$NON-NLS-1$
 

--- a/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/HttpContextManager.java
+++ b/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/HttpContextManager.java
@@ -25,7 +25,7 @@ import org.osgi.framework.Bundle;
 
 public class HttpContextManager implements Listener {
 
-	private static final String HTTPCONTEXTS_EXTENSION_POINT = "org.eclipse.equinox.http.registry.httpcontexts"; //$NON-NLS-1$
+	private static final String HTTPCONTEXTS_EXTENSION_POINT = "org.eclipse.rap.http.registry.httpcontexts"; //$NON-NLS-1$
 	private static final String HTTPCONTEXT = "httpcontext"; //$NON-NLS-1$
 	private static final String NAME = "name"; //$NON-NLS-1$
 	private static final String ID = "id"; //$NON-NLS-1$

--- a/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/ResourceManager.java
+++ b/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/ResourceManager.java
@@ -22,7 +22,7 @@ import org.osgi.framework.*;
 
 public class ResourceManager implements ExtensionPointTracker.Listener {
 
-	private static final String RESOURCES_EXTENSION_POINT = "org.eclipse.equinox.http.registry.resources"; //$NON-NLS-1$
+	private static final String RESOURCES_EXTENSION_POINT = "org.eclipse.rap.http.registry.resources"; //$NON-NLS-1$
 
 	private static final String HTTPCONTEXT_NAME = "httpcontext-name"; //$NON-NLS-1$
 

--- a/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/ServletManager.java
+++ b/bundles/org.eclipse.rap.http.registry/src/org/eclipse/rap/http/registry/internal/ServletManager.java
@@ -23,7 +23,7 @@ import org.osgi.framework.*;
 
 public class ServletManager implements ExtensionPointTracker.Listener {
 
-	private static final String SERVLETS_EXTENSION_POINT = "org.eclipse.equinox.http.registry.servlets"; //$NON-NLS-1$
+	private static final String SERVLETS_EXTENSION_POINT = "org.eclipse.rap.http.registry.servlets"; //$NON-NLS-1$
 
 	private static final String HTTPCONTEXT_NAME = "httpcontext-name"; //$NON-NLS-1$
 


### PR DESCRIPTION
The extension ponit names has been renamed in RAP 4.0 from "org.eclipse.equinox.http.registry.*" to
"org.eclipse.rap.http.registry.*"

Fix: https://github.com/eclipse-rap/org.eclipse.rap/issues/223