### PR TITLE
prevent double loading overlay

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/runtime/ErrorHandler.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/runtime/ErrorHandler.js
@@ -114,11 +114,13 @@ rwt.qx.Class.define( "rwt.runtime.ErrorHandler", {
     },
 
     showWaitHint : function() {
-      this._overlay = this._createOverlay();
+	  if (this._overlay === null) {
+      	this._overlay = this._createOverlay();
+      }
       var themeStore = rwt.theme.ThemeStore.getInstance();
       var cssElement = "SystemMessage-DisplayOverlay";
       var icon = themeStore.getSizedImage( cssElement, {}, "background-image" );
-      if( icon && icon[ 0 ] ) {
+      if( this._box === null && icon && icon[ 0 ] ) {
         this._box = this._createErrorBoxArea( icon[ 1 ], icon[ 2 ] );
         rwt.html.Style.setBackgroundImage( this._box, icon[ 0 ] );
         this._box.style.backgroundColor = "transparent";


### PR DESCRIPTION
if showWaitHint was called twice, another overlay would be created and only the second would be cleaned later.

Also-by: Ralf Schlesinger <ralf.schlesinger@robotron.de>