### PR TITLE
Increment org.eclipse.rap.servletbridge package export version

### DIFF
--- a/bundles/org.eclipse.rap.servletbridge/src/org/eclipse/rap/servletbridge/FrameworkLauncher.java
+++ b/bundles/org.eclipse.rap.servletbridge/src/org/eclipse/rap/servletbridge/FrameworkLauncher.java
@@ -65,7 +65,7 @@ public class FrameworkLauncher {
 	protected static final String LAUNCH_INI = "launch.ini"; //$NON-NLS-1$
 
 	private static final String EXTENSIONBUNDLE_DEFAULT_BSN = "org.eclipse.rap.servletbridge.extensionbundle"; //$NON-NLS-1$
-	private static final String EXTENSIONBUNDLE_DEFAULT_VERSION = "4.0.0"; //$NON-NLS-1$
+	private static final String EXTENSIONBUNDLE_DEFAULT_VERSION = "4.1.0"; //$NON-NLS-1$
 	private static final String MANIFEST_VERSION = "Manifest-Version"; //$NON-NLS-1$
 	private static final String BUNDLE_MANIFEST_VERSION = "Bundle-ManifestVersion"; //$NON-NLS-1$
 	private static final String BUNDLE_NAME = "Bundle-Name"; //$NON-NLS-1$
@@ -256,7 +256,7 @@ public class FrameworkLauncher {
 		String packageExports = null;
 		String servletVersion = context.getMajorVersion() + "." + context.getMinorVersion(); //$NON-NLS-1$
 		if (context.getMajorVersion() >= 6) {
-			packageExports = "org.eclipse.rap.servletbridge; version=4.0" + //$NON-NLS-1$
+			packageExports = "org.eclipse.rap.servletbridge; version=4.1" + //$NON-NLS-1$
 					", jakarta.servlet; version=" + servletVersion + //$NON-NLS-1$
 					", jakarta.servlet.annotation; version=" + servletVersion + //$NON-NLS-1$
 					", jakarta.servlet.descriptor; version=" + servletVersion + //$NON-NLS-1$


### PR DESCRIPTION
When incrementing bundle versions it is important in the future to increment the version of the package export of
`org.eclipse.rap.servletbridge` in the `FrameworkLauncher` to match the new version.

Also update the `EXTENSIONBUNDLE_DEFAULT_VERSION` to use the same version everywhere.