### PR TITLE
Add helper methods to use lambda expressions for listeners methods

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/accessibility/AccessibleListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/accessibility/AccessibleListener.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
+import java.util.function.Consumer;
 
 import org.eclipse.swt.internal.SWTEventListener;
 
@@ -123,4 +124,68 @@ public interface AccessibleListener extends SWTEventListener {
 	 * </ul>
 	 */
 	public void getDescription(AccessibleEvent e);
+	
+    /**
+     * Static helper method to create a <code>AccessibleListener</code> for the
+     * {@link #getName(AccessibleEvent e)}) method with a lambda expression.
+     *
+     * @param c the consumer of the event
+     * @return AccessibleListener
+     */
+    public static AccessibleListener getNameAdapter(Consumer<AccessibleEvent> c) {
+        return new AccessibleAdapter() {
+            @Override
+            public void getName(AccessibleEvent e) {
+                c.accept(e);
+            }
+        };
+    }
+
+    /**
+     * Static helper method to create a <code>AccessibleListener</code> for the
+     * {@link #getHelp(AccessibleEvent e)}) method with a lambda expression.
+     *
+     * @param c the consumer of the event
+     * @return AccessibleListener
+     */
+    public static AccessibleListener getHelpAdapter(Consumer<AccessibleEvent> c) {
+        return new AccessibleAdapter() {
+            @Override
+            public void getHelp(AccessibleEvent e) {
+                c.accept(e);
+            }
+        };
+    }
+
+    /**
+     * Static helper method to create a <code>AccessibleListener</code> for the
+     * {@link #getKeyboardShortcut(AccessibleEvent e)}) method with a lambda expression.
+     *
+     * @param c the consumer of the event
+     * @return AccessibleListener
+     */
+    public static AccessibleListener getKeyboardShortcutAdapter(Consumer<AccessibleEvent> c) {
+        return new AccessibleAdapter() {
+            @Override
+            public void getKeyboardShortcut(AccessibleEvent e) {
+                c.accept(e);
+            }
+        };
+    }
+
+    /**
+     * Static helper method to create a <code>AccessibleListener</code> for the
+     * {@link #getDescription(AccessibleEvent e)}) method with a lambda expression.
+     *
+     * @param c the consumer of the event
+     * @return AccessibleListener
+     */
+    public static AccessibleListener getDescriptionAdapter(Consumer<AccessibleEvent> c) {
+        return new AccessibleAdapter() {
+            @Override
+            public void getDescription(AccessibleEvent e) {
+                c.accept(e);
+            }
+        };
+    }
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/accessibility/AccessibleListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/accessibility/AccessibleListener.java
@@ -131,6 +131,7 @@ public interface AccessibleListener extends SWTEventListener {
      *
      * @param c the consumer of the event
      * @return AccessibleListener
+     * @since 4.1
      */
     public static AccessibleListener getNameAdapter(Consumer<AccessibleEvent> c) {
         return new AccessibleAdapter() {
@@ -147,6 +148,7 @@ public interface AccessibleListener extends SWTEventListener {
      *
      * @param c the consumer of the event
      * @return AccessibleListener
+     * @since 4.1
      */
     public static AccessibleListener getHelpAdapter(Consumer<AccessibleEvent> c) {
         return new AccessibleAdapter() {
@@ -163,6 +165,7 @@ public interface AccessibleListener extends SWTEventListener {
      *
      * @param c the consumer of the event
      * @return AccessibleListener
+     * @since 4.1
      */
     public static AccessibleListener getKeyboardShortcutAdapter(Consumer<AccessibleEvent> c) {
         return new AccessibleAdapter() {
@@ -179,6 +182,7 @@ public interface AccessibleListener extends SWTEventListener {
      *
      * @param c the consumer of the event
      * @return AccessibleListener
+     * @since 4.1
      */
     public static AccessibleListener getDescriptionAdapter(Consumer<AccessibleEvent> c) {
         return new AccessibleAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/LocationListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/LocationListener.java
@@ -67,6 +67,7 @@ public void changed(LocationEvent event);
  *
  * @param c the consumer of the event
  * @return LocationListener
+ * @since 4.1
  */
 public static LocationListener changingAdapter(Consumer<LocationEvent> c) {
     return new LocationAdapter() {
@@ -83,6 +84,7 @@ public static LocationListener changingAdapter(Consumer<LocationEvent> c) {
  *
  * @param c the consumer of the event
  * @return LocationListener
+ * @since 4.1
  */
 public static LocationListener changedAdapter(Consumer<LocationEvent> c) {
     return new LocationAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/LocationListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/LocationListener.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 
@@ -59,4 +61,35 @@ public void changing(LocationEvent event);
  */ 
 public void changed(LocationEvent event);
 
+/**
+ * Static helper method to create a <code>LocationListener</code> for the
+ * {@link #changing(LocationEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return LocationListener
+ */
+public static LocationListener changingAdapter(Consumer<LocationEvent> c) {
+    return new LocationAdapter() {
+        @Override
+        public void changing(LocationEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>LocationListener</code> for the
+ * {@link #changed(LocationEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return LocationListener
+ */
+public static LocationListener changedAdapter(Consumer<LocationEvent> c) {
+    return new LocationAdapter() {
+        @Override
+        public void changed(LocationEvent e) {
+            c.accept(e);
+        }
+    };
+}
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/ProgressListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/ProgressListener.java
@@ -62,7 +62,8 @@ public interface ProgressListener extends SWTEventListener {
    * {@link #changed(ProgressEvent e)}) method, given a lambda expression or a method reference.
    *
    * @param c the consumer of the event
-   * @return LocationListener
+   * @return ProgressListener
+   * @since 4.1
    */
   public static ProgressListener changedAdapter(Consumer<ProgressEvent> c) {
       return new ProgressAdapter() {
@@ -78,7 +79,8 @@ public interface ProgressListener extends SWTEventListener {
    * {@link #completed(ProgressEvent e)}) method, given a lambda expression or a method reference.
    *
    * @param c the consumer of the event
-   * @return LocationListener
+   * @return ProgressListener
+   * @since 4.1
    */
   public static ProgressListener completedAdapter(Consumer<ProgressEvent> c) {
       return new ProgressAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/ProgressListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/browser/ProgressListener.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -54,4 +56,36 @@ public interface ProgressListener extends SWTEventListener {
    *          <code>Browser</code> that has loaded its current URL.
    */
   public void completed( ProgressEvent event );
+  
+  /**
+   * Static helper method to create a <code>ProgressListener</code> for the
+   * {@link #changed(ProgressEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return LocationListener
+   */
+  public static ProgressListener changedAdapter(Consumer<ProgressEvent> c) {
+      return new ProgressAdapter() {
+          @Override
+          public void changed(ProgressEvent e) {
+              c.accept(e);
+          }
+      };
+  }
+
+  /**
+   * Static helper method to create a <code>ProgressListener</code> for the
+   * {@link #completed(ProgressEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return LocationListener
+   */
+  public static ProgressListener completedAdapter(Consumer<ProgressEvent> c) {
+      return new ProgressAdapter() {
+          @Override
+          public void completed(ProgressEvent e) {
+              c.accept(e);
+          }
+      };
+  }
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/custom/CTabFolder2Listener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/custom/CTabFolder2Listener.java
@@ -118,6 +118,7 @@ public void showList(CTabFolderEvent event);
  *
  * @param c the consumer of the event
  * @return CTabFolder2Listener
+ * @since 4.1
  */
 public static CTabFolder2Listener closeAdapter(Consumer<CTabFolderEvent> c) {
     return new CTabFolder2Adapter() {
@@ -134,6 +135,7 @@ public static CTabFolder2Listener closeAdapter(Consumer<CTabFolderEvent> c) {
  *
  * @param c the consumer of the event
  * @return CTabFolder2Listener
+ * @since 4.1
  */
 public static CTabFolder2Listener minimizeAdapter(Consumer<CTabFolderEvent> c) {
     return new CTabFolder2Adapter() {
@@ -150,6 +152,7 @@ public static CTabFolder2Listener minimizeAdapter(Consumer<CTabFolderEvent> c) {
  *
  * @param c the consumer of the event
  * @return CTabFolder2Listener
+ * @since 4.1
  */
 public static CTabFolder2Listener maximizeAdapter(Consumer<CTabFolderEvent> c) {
     return new CTabFolder2Adapter() {
@@ -166,6 +169,7 @@ public static CTabFolder2Listener maximizeAdapter(Consumer<CTabFolderEvent> c) {
  *
  * @param c the consumer of the event
  * @return CTabFolder2Listener
+ * @since 4.1
  */
 public static CTabFolder2Listener restoreAdapter(Consumer<CTabFolderEvent> c) {
     return new CTabFolder2Adapter() {
@@ -182,6 +186,7 @@ public static CTabFolder2Listener restoreAdapter(Consumer<CTabFolderEvent> c) {
  *
  * @param c the consumer of the event
  * @return CTabFolder2Listener
+ * @since 4.1
  */
 public static CTabFolder2Listener showListAdapter(Consumer<CTabFolderEvent> c) {
     return new CTabFolder2Adapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/custom/CTabFolder2Listener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/custom/CTabFolder2Listener.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.eclipse.swt.custom;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -109,4 +111,84 @@ public void restore(CTabFolderEvent event);
  * @see CTabFolder#setSelection(CTabItem)
  */
 public void showList(CTabFolderEvent event);
+
+/**
+ * Static helper method to create a <code>CTabFolder2Listener</code> for the
+ * {@link #close(CTabFolderEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return CTabFolder2Listener
+ */
+public static CTabFolder2Listener closeAdapter(Consumer<CTabFolderEvent> c) {
+    return new CTabFolder2Adapter() {
+        @Override
+        public void close(CTabFolderEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>CTabFolder2Listener</code> for the
+ * {@link #minimize(CTabFolderEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return CTabFolder2Listener
+ */
+public static CTabFolder2Listener minimizeAdapter(Consumer<CTabFolderEvent> c) {
+    return new CTabFolder2Adapter() {
+        @Override
+        public void minimize(CTabFolderEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>CTabFolder2Listener</code> for the
+ * {@link #maximize(CTabFolderEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return CTabFolder2Listener
+ */
+public static CTabFolder2Listener maximizeAdapter(Consumer<CTabFolderEvent> c) {
+    return new CTabFolder2Adapter() {
+        @Override
+        public void maximize(CTabFolderEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>CTabFolder2Listener</code> for the
+ * {@link #restore(CTabFolderEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return CTabFolder2Listener
+ */
+public static CTabFolder2Listener restoreAdapter(Consumer<CTabFolderEvent> c) {
+    return new CTabFolder2Adapter() {
+        @Override
+        public void restore(CTabFolderEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>CTabFolder2Listener</code> for the
+ * {@link #showList(CTabFolderEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return CTabFolder2Listener
+ */
+public static CTabFolder2Listener showListAdapter(Consumer<CTabFolderEvent> c) {
+    return new CTabFolder2Adapter() {
+        @Override
+        public void showList(CTabFolderEvent e) {
+            c.accept(e);
+        }
+    };
+}
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ControlListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ControlListener.java
@@ -50,6 +50,7 @@ public interface ControlListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return ControlListener
+   * @since 4.1
    */
   static ControlListener controlMovedAdapter(Consumer<ControlEvent> c) {
       return new ControlAdapter() {
@@ -66,6 +67,7 @@ public interface ControlListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return ControlListener
+   * @since 4.1
    */
   static ControlListener controlResizedAdapter(Consumer<ControlEvent> c) {
       return new ControlAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ControlListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ControlListener.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -41,4 +43,36 @@ public interface ControlListener extends SWTEventListener {
    * @param e an event containing information about the resize
    */
   void controlResized( ControlEvent e );
+  
+  /**
+   * Static helper method to create a <code>ControlListener</code> for the
+   * {@link #controlMoved(ControlEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return ControlListener
+   */
+  static ControlListener controlMovedAdapter(Consumer<ControlEvent> c) {
+      return new ControlAdapter() {
+          @Override
+          public void controlMoved(ControlEvent e) {
+              c.accept(e);
+          }
+      };
+  }
+
+  /**
+   * Static helper method to create a <code>ControlListener</code> for the
+   * {@link #controlResized(ControlEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return ControlListener
+   */
+  static ControlListener controlResizedAdapter(Consumer<ControlEvent> c) {
+      return new ControlAdapter() {
+          @Override
+          public void controlResized(ControlEvent e) {
+              c.accept(e);
+          }
+      };
+  }
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ExpandListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ExpandListener.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -43,4 +45,36 @@ public interface ExpandListener extends SWTEventListener {
    * @param e an event containing information about the operation
    */
   public void itemExpanded( ExpandEvent e );
+  
+  /**
+   * Static helper method to create a <code>ExpandListener</code> for the
+   * {@link #itemCollapsed(ExpandEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return ExpandListener
+   */
+  static ExpandListener itemCollapsedAdapter(Consumer<ExpandEvent> c) {
+      return new ExpandAdapter() {
+          @Override
+          public void itemCollapsed(ExpandEvent e) {
+              c.accept(e);
+          }
+      };
+  }
+
+  /**
+   * Static helper method to create a <code>ExpandListener</code> for the
+   * {@link #itemExpanded(ExpandEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return ExpandListener
+   */
+  static ExpandListener itemExpandedAdapter(Consumer<ExpandEvent> c) {
+      return new ExpandAdapter() {
+          @Override
+          public void itemExpanded(ExpandEvent e) {
+              c.accept(e);
+          }
+      };
+  }
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ExpandListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ExpandListener.java
@@ -52,6 +52,7 @@ public interface ExpandListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return ExpandListener
+   * @since 4.1
    */
   static ExpandListener itemCollapsedAdapter(Consumer<ExpandEvent> c) {
       return new ExpandAdapter() {
@@ -68,6 +69,7 @@ public interface ExpandListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return ExpandListener
+   * @since 4.1
    */
   static ExpandListener itemExpandedAdapter(Consumer<ExpandEvent> c) {
       return new ExpandAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/FocusListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/FocusListener.java
@@ -49,6 +49,7 @@ public interface FocusListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return FocusListener
+   * @since 4.1
    */
   static FocusListener focusGainedAdapter(Consumer<FocusEvent> c) {
       return new FocusAdapter() {
@@ -65,6 +66,7 @@ public interface FocusListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return FocusListener
+   * @since 4.1
   */
   static FocusListener focusLostAdapter(Consumer<FocusEvent> c) {
       return new FocusAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/FocusListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/FocusListener.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -40,4 +42,36 @@ public interface FocusListener extends SWTEventListener {
    * @param event an event containing information about the focus change
    */
   public void focusLost( FocusEvent event );
+  
+  /**
+   * Static helper method to create a <code>FocusListener</code> for the
+   * {@link #focusGained(FocusEvent e)}) method with a lambda expression.
+   *
+   * @param c the consumer of the event
+   * @return FocusListener
+   */
+  static FocusListener focusGainedAdapter(Consumer<FocusEvent> c) {
+      return new FocusAdapter() {
+          @Override
+          public void focusGained(FocusEvent e) {
+              c.accept(e);
+          }
+      };
+  }
+
+  /**
+   * Static helper method to create a <code>FocusListener</code> for the
+   * {@link #focusLost(FocusEvent e)}) method with a lambda expression.
+   *
+   * @param c the consumer of the event
+   * @return FocusListener
+  */
+  static FocusListener focusLostAdapter(Consumer<FocusEvent> c) {
+      return new FocusAdapter() {
+          @Override
+          public void focusLost(FocusEvent e) {
+              c.accept(e);
+          }
+      };
+  }
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/KeyListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/KeyListener.java
@@ -54,6 +54,7 @@ public void keyReleased(KeyEvent e);
  *
  * @param c the consumer of the event
  * @return KeyListener
+ * @since 4.1
  */
 static KeyListener keyPressedAdapter(Consumer<KeyEvent> c) {
     return new KeyAdapter() {
@@ -70,6 +71,7 @@ static KeyListener keyPressedAdapter(Consumer<KeyEvent> c) {
  *
  * @param c the consumer of the event
  * @return KeyListener
+ * @since 4.1
 */
 static KeyListener keyReleasedAdapter(Consumer<KeyEvent> c) {
     return new KeyAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/KeyListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/KeyListener.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
 
 import org.eclipse.swt.internal.SWTEventListener;
 
@@ -46,4 +47,36 @@ public void keyPressed(KeyEvent e);
  * @param e an event containing information about the key release
  */
 public void keyReleased(KeyEvent e);
+
+/**
+ * Static helper method to create a <code>KeyListener</code> for the
+ * {@link #keyPressed(KeyEvent e)}) method with a lambda expression.
+ *
+ * @param c the consumer of the event
+ * @return KeyListener
+ */
+static KeyListener keyPressedAdapter(Consumer<KeyEvent> c) {
+    return new KeyAdapter() {
+        @Override
+        public void keyPressed(KeyEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>KeyListener</code> for the
+ * {@link #keyReleased(KeyEvent e)}) method with a lambda expression.
+ *
+ * @param c the consumer of the event
+ * @return KeyListener
+*/
+static KeyListener keyReleasedAdapter(Consumer<KeyEvent> c) {
+    return new KeyAdapter() {
+        @Override
+        public void keyReleased(KeyEvent e) {
+            c.accept(e);
+        }
+    };
+}
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MenuListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MenuListener.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -44,4 +46,35 @@ public interface MenuListener extends SWTEventListener {
 	 */
 	public void menuShown(MenuEvent e);
 
+	/**
+	 * Static helper method to create a <code>MenuListener</code> for the
+	 * {@link #menuHidden(MenuEvent e)}) method, given a lambda expression or a method reference.
+	 *
+	 * @param c the consumer of the event
+	 * @return MenuListener
+	 */
+	static MenuListener menuHiddenAdapter(Consumer<MenuEvent> c) {
+	    return new MenuAdapter() {
+	        @Override
+	        public void menuHidden(MenuEvent e) {
+	            c.accept(e);
+	        }
+	    };
+	}
+
+	/**
+	 * Static helper method to create a <code>MenuListener</code> for the
+	 * {@link #menuShown(MenuEvent e)}) method, given a lambda expression or a method reference.
+	 *
+	 * @param c the consumer of the event
+	 * @return MenuListener
+	 */
+	static MenuListener menuShownAdapter(Consumer<MenuEvent> c) {
+	    return new MenuAdapter() {
+	        @Override
+	        public void menuShown(MenuEvent e) {
+	            c.accept(e);
+	        }
+	    };
+	}
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MenuListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MenuListener.java
@@ -52,6 +52,7 @@ public interface MenuListener extends SWTEventListener {
 	 *
 	 * @param c the consumer of the event
 	 * @return MenuListener
+	 * @since 4.1
 	 */
 	static MenuListener menuHiddenAdapter(Consumer<MenuEvent> c) {
 	    return new MenuAdapter() {
@@ -68,6 +69,7 @@ public interface MenuListener extends SWTEventListener {
 	 *
 	 * @param c the consumer of the event
 	 * @return MenuListener
+	 * @since 4.1
 	 */
 	static MenuListener menuShownAdapter(Consumer<MenuEvent> c) {
 	    return new MenuAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseListener.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
 
 import org.eclipse.swt.internal.SWTEventListener;
 
@@ -56,4 +57,52 @@ public void mouseDown(MouseEvent e);
  * @param e an event containing information about the mouse button release
  */
 public void mouseUp(MouseEvent e);
+
+/**
+ * Static helper method to create a <code>MouseListener</code> for the
+ * {@link #mouseDoubleClick(MouseEvent e)}) method with a lambda expression.
+ *
+ * @param c the consumer of the event
+ * @return MouseListener
+ */
+static MouseListener mouseDoubleClickAdapter(Consumer<MouseEvent> c) {
+    return new MouseAdapter() {
+        @Override
+        public void mouseDoubleClick(MouseEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>MouseListener</code> for the
+ * {@link #mouseDown(MouseEvent e)}) method with a lambda expression.
+ *
+ * @param c the consumer of the event
+ * @return MouseListener
+ */
+static MouseListener mouseDownAdapter(Consumer<MouseEvent> c) {
+    return new MouseAdapter() {
+        @Override
+        public void mouseDown(MouseEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>MouseListener</code> for the
+ * {@link #mouseUp(MouseEvent e)}) method with a lambda expression.
+ *
+ * @param c the consumer of the event
+ * @return MouseListener
+ */
+static MouseListener mouseUpAdapter(Consumer<MouseEvent> c) {
+    return new MouseAdapter() {
+        @Override
+        public void mouseUp(MouseEvent e) {
+            c.accept(e);
+        }
+    };
+}
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseListener.java
@@ -64,6 +64,7 @@ public void mouseUp(MouseEvent e);
  *
  * @param c the consumer of the event
  * @return MouseListener
+ * @since 4.1
  */
 static MouseListener mouseDoubleClickAdapter(Consumer<MouseEvent> c) {
     return new MouseAdapter() {
@@ -80,6 +81,7 @@ static MouseListener mouseDoubleClickAdapter(Consumer<MouseEvent> c) {
  *
  * @param c the consumer of the event
  * @return MouseListener
+ * @since 4.1
  */
 static MouseListener mouseDownAdapter(Consumer<MouseEvent> c) {
     return new MouseAdapter() {
@@ -96,6 +98,7 @@ static MouseListener mouseDownAdapter(Consumer<MouseEvent> c) {
  *
  * @param c the consumer of the event
  * @return MouseListener
+ * @since 4.1
  */
 static MouseListener mouseUpAdapter(Consumer<MouseEvent> c) {
     return new MouseAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseTrackListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseTrackListener.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -54,4 +56,52 @@ public interface MouseTrackListener extends SWTEventListener {
    * @param e an event containing information about the hover
    */
   public void mouseHover( MouseEvent e );
+  
+  /**
+   * Static helper method to create a <code>MouseTrackListener</code> for the
+   * {@link #mouseEnter(MouseEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return MouseTrackListener
+   */
+  static MouseTrackListener mouseEnterAdapter(Consumer<MouseEvent> c) {
+      return new MouseTrackAdapter() {
+          @Override
+          public void mouseEnter(MouseEvent e) {
+              c.accept(e);
+          }
+      };
+  }
+
+  /**
+   * Static helper method to create a <code>MouseTrackListener</code> for the
+   * {@link #mouseExit(MouseEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return MouseTrackListener
+   */
+  static MouseTrackListener mouseExitAdapter(Consumer<MouseEvent> c) {
+      return new MouseTrackAdapter() {
+          @Override
+          public void mouseExit(MouseEvent e) {
+              c.accept(e);
+          }
+      };
+  }
+
+  /**
+   * Static helper method to create a <code>MouseTrackListener</code> for the
+   * {@link #mouseHover(MouseEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return MouseTrackListener
+   */
+  static MouseTrackListener mouseHoverAdapter(Consumer<MouseEvent> c) {
+      return new MouseTrackAdapter() {
+          @Override
+          public void mouseHover(MouseEvent e) {
+              c.accept(e);
+          }
+      };
+  }
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseTrackListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/MouseTrackListener.java
@@ -63,6 +63,7 @@ public interface MouseTrackListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return MouseTrackListener
+   * @since 4.1
    */
   static MouseTrackListener mouseEnterAdapter(Consumer<MouseEvent> c) {
       return new MouseTrackAdapter() {
@@ -79,6 +80,7 @@ public interface MouseTrackListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return MouseTrackListener
+   * @since 4.1
    */
   static MouseTrackListener mouseExitAdapter(Consumer<MouseEvent> c) {
       return new MouseTrackAdapter() {
@@ -95,6 +97,7 @@ public interface MouseTrackListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return MouseTrackListener
+   * @since 4.1
    */
   static MouseTrackListener mouseHoverAdapter(Consumer<MouseEvent> c) {
       return new MouseTrackAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/SelectionListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/SelectionListener.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -59,4 +61,38 @@ public void widgetSelected(SelectionEvent e);
  * @param e an event containing information about the default selection
  */
 public void widgetDefaultSelected(SelectionEvent e);
+
+/**
+ * Static helper method to create a <code>SelectionListener</code> for the
+ * {@link #widgetSelected(SelectionEvent e)}) method, given a lambda expression
+ * or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return SelectionListener
+ */
+static SelectionListener widgetSelectedAdapter(Consumer<SelectionEvent> c) {
+    return new SelectionAdapter() {
+        @Override
+        public void widgetSelected(SelectionEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>SelectionListener</code> for the
+ * {@link #widgetDefaultSelected(SelectionEvent e)}) method, given a lambda expression
+ * or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return SelectionListener
+*/
+static SelectionListener widgetDefaultSelectedAdapter(Consumer<SelectionEvent> c) {
+    return new SelectionAdapter() {
+        @Override
+        public void widgetDefaultSelected(SelectionEvent e) {
+            c.accept(e);
+        }
+    };
+}
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/SelectionListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/SelectionListener.java
@@ -69,6 +69,7 @@ public void widgetDefaultSelected(SelectionEvent e);
  *
  * @param c the consumer of the event
  * @return SelectionListener
+ * @since 4.1
  */
 static SelectionListener widgetSelectedAdapter(Consumer<SelectionEvent> c) {
     return new SelectionAdapter() {
@@ -86,6 +87,7 @@ static SelectionListener widgetSelectedAdapter(Consumer<SelectionEvent> c) {
  *
  * @param c the consumer of the event
  * @return SelectionListener
+ * @since 4.1
 */
 static SelectionListener widgetDefaultSelectedAdapter(Consumer<SelectionEvent> c) {
     return new SelectionAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ShellListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ShellListener.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
 
 import org.eclipse.swt.internal.SWTEventListener;
 
@@ -65,5 +66,53 @@ public void shellDeactivated(ShellEvent e);
  * @param e an event containing information about the minimization
  */
 //public void shellIconified(ShellEvent e);
+
+/**
+ * Static helper method to create a <code>ShellListener</code> for the
+ * {@link #shellActivated(ShellEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return ShellListener
+ */
+static ShellListener shellActivatedAdapter(Consumer<ShellEvent> c) {
+    return new ShellAdapter() {
+        @Override
+        public void shellActivated(ShellEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>ShellListener</code> for the
+ * {@link #shellClosed(ShellEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return ShellListener
+ */
+static ShellListener shellClosedAdapter(Consumer<ShellEvent> c) {
+    return new ShellAdapter() {
+        @Override
+        public void shellClosed(ShellEvent e) {
+            c.accept(e);
+        }
+    };
+}
+
+/**
+ * Static helper method to create a <code>ShellListener</code> for the
+ * {@link #shellDeactivated(ShellEvent e)}) method, given a lambda expression or a method reference.
+ *
+ * @param c the consumer of the event
+ * @return ShellListener
+ */
+static ShellListener shellDeactivatedAdapter(Consumer<ShellEvent> c) {
+    return new ShellAdapter() {
+        @Override
+        public void shellDeactivated(ShellEvent e) {
+            c.accept(e);
+        }
+    };
+}
 }
 

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ShellListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/ShellListener.java
@@ -73,6 +73,7 @@ public void shellDeactivated(ShellEvent e);
  *
  * @param c the consumer of the event
  * @return ShellListener
+ * @since 4.1
  */
 static ShellListener shellActivatedAdapter(Consumer<ShellEvent> c) {
     return new ShellAdapter() {
@@ -89,6 +90,7 @@ static ShellListener shellActivatedAdapter(Consumer<ShellEvent> c) {
  *
  * @param c the consumer of the event
  * @return ShellListener
+ * @since 4.1
  */
 static ShellListener shellClosedAdapter(Consumer<ShellEvent> c) {
     return new ShellAdapter() {
@@ -105,6 +107,7 @@ static ShellListener shellClosedAdapter(Consumer<ShellEvent> c) {
  *
  * @param c the consumer of the event
  * @return ShellListener
+ * @since 4.1
  */
 static ShellListener shellDeactivatedAdapter(Consumer<ShellEvent> c) {
     return new ShellAdapter() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/TreeListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/TreeListener.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.eclipse.swt.events;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.internal.SWTEventListener;
 
 /**
@@ -40,4 +42,36 @@ public interface TreeListener extends SWTEventListener {
    * @param e an event containing information about the tree operation
    */
   void treeExpanded( TreeEvent e );
+  
+  /**
+   * Static helper method to create a <code>TreeListener</code> for the
+   * {@link #treeCollapsed(TreeEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return TreeListener
+   */
+  static TreeListener treeCollapsedAdapter(Consumer<TreeEvent> c) {
+      return new TreeAdapter() {
+          @Override
+          public void treeCollapsed(TreeEvent e) {
+              c.accept(e);
+          }
+      };
+  }
+
+  /**
+   * Static helper method to create a <code>TreeListener</code> for the
+   * {@link #treeExpanded(TreeEvent e)}) method, given a lambda expression or a method reference.
+   *
+   * @param c the consumer of the event
+   * @return TreeListener
+   */
+  static TreeListener treeExpandedAdapter(Consumer<TreeEvent> c) {
+      return new TreeAdapter() {
+          @Override
+          public void treeExpanded(TreeEvent e) {
+              c.accept(e);
+          }
+      };
+  }
 }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/TreeListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/events/TreeListener.java
@@ -49,6 +49,7 @@ public interface TreeListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return TreeListener
+   * @since 4.1
    */
   static TreeListener treeCollapsedAdapter(Consumer<TreeEvent> c) {
       return new TreeAdapter() {
@@ -65,6 +66,7 @@ public interface TreeListener extends SWTEventListener {
    *
    * @param c the consumer of the event
    * @return TreeListener
+   * @since 4.1
    */
   static TreeListener treeExpandedAdapter(Consumer<TreeEvent> c) {
       return new TreeAdapter() {


### PR DESCRIPTION
The helper methods to use lambda expressions in SWT listeners are missing in RAP.
Adding them avoids the need to convert existing lambda expressions into adapters in a new single-source application.