### PR TITLE
Fix file upload in Tomcat 11

### DIFF
--- a/bundles/org.eclipse.rap.fileupload/src/org/eclipse/rap/fileupload/internal/FileUploadServiceHandler.java
+++ b/bundles/org.eclipse.rap.fileupload/src/org/eclipse/rap/fileupload/internal/FileUploadServiceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2024 EclipseSource and others.
+ * Copyright (c) 2002, 2025 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,8 @@
  ******************************************************************************/
 package org.eclipse.rap.fileupload.internal;
 
+import static org.eclipse.rap.rwt.internal.util.HTTP.getParameter;
+
 import java.io.IOException;
 
 import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
@@ -24,7 +26,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-
+@SuppressWarnings( "restriction" )
 public final class FileUploadServiceHandler implements ServiceHandler {
 
   private static final String PARAMETER_TOKEN = "token";
@@ -39,7 +41,7 @@ public final class FileUploadServiceHandler implements ServiceHandler {
     // Ignore requests to this service handler without a valid session for security reasons
     boolean hasSession = request.getSession( false ) != null;
     if( hasSession ) {
-      String token = request.getParameter( PARAMETER_TOKEN );
+      String token = getParameter( request, PARAMETER_TOKEN );
       FileUploadHandler registeredHandler = FileUploadHandlerStore.getInstance().getHandler( token );
       if( registeredHandler == null ) {
         String message = "Invalid or missing token";

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/engine/RWTServlet.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/engine/RWTServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2024 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2025 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static org.eclipse.rap.rwt.internal.protocol.ClientMessageConst.CONNECTION_ID;
 import static org.eclipse.rap.rwt.internal.util.HTTP.CONTENT_TYPE_JSON;
 import static org.eclipse.rap.rwt.internal.util.HTTP.METHOD_POST;
+import static org.eclipse.rap.rwt.internal.util.HTTP.getParameter;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -154,7 +155,7 @@ public class RWTServlet extends HttpServlet {
   }
 
   private static boolean isServiceHandlerRequest( HttpServletRequest request ) {
-    return request.getParameter( ServiceManagerImpl.REQUEST_PARAM ) != null;
+    return getParameter( request, ServiceManagerImpl.REQUEST_PARAM ) != null;
   }
 
   private static boolean isContentTypeValid( ServletRequest request ) {
@@ -176,7 +177,7 @@ public class RWTServlet extends HttpServlet {
   private static void prepareUISession( ServiceContext context ) {
     HttpServletRequest request = context.getRequest();
     HttpSession httpSession = request.getSession( true );
-    String connectionId = request.getParameter( CONNECTION_ID );
+    String connectionId = getParameter( request, CONNECTION_ID );
     if( connectionId != null ) {
       context.setUISession( UISessionImpl.getInstanceFromSession( httpSession, connectionId ) );
     } else if( isUIRequest( request ) ) {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/ServiceManagerImpl.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/ServiceManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2021 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2025 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@
 package org.eclipse.rap.rwt.internal.service;
 
 import static org.eclipse.rap.rwt.internal.protocol.ClientMessageConst.CONNECTION_ID;
+import static org.eclipse.rap.rwt.internal.util.HTTP.getParameter;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 import org.eclipse.rap.rwt.internal.RWTProperties;
 import org.eclipse.rap.rwt.internal.util.ParamCheck;
 import org.eclipse.rap.rwt.service.ServiceHandler;
 import org.eclipse.rap.rwt.service.ServiceManager;
 import org.eclipse.rap.rwt.service.UISession;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 
 public class ServiceManagerImpl implements ServiceManager {
@@ -108,7 +109,7 @@ public class ServiceManagerImpl implements ServiceManager {
   }
 
   private static String getCustomHandlerId() {
-    return ContextProvider.getRequest().getParameter( REQUEST_PARAM );
+    return getParameter( ContextProvider.getRequest(), REQUEST_PARAM );
   }
 
   private static String getConnectionId() {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/util/HTTP.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/util/HTTP.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2015 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2025 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,16 @@
  ******************************************************************************/
 package org.eclipse.rap.rwt.internal.util;
 
+import static java.net.URLDecoder.decode;
+
+import java.io.UnsupportedEncodingException;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Constant utility class which provides commonly used strings for HTTP.
@@ -20,11 +30,69 @@ public final class HTTP {
   public static final String CONTENT_TYPE_HTML = "text/html";
   public static final String CONTENT_TYPE_JAVASCRIPT = "text/javascript";
   public static final String CONTENT_TYPE_JSON = "application/json"; // RFC 4627
+  public static final String CONTENT_TYPE_MULTIPART = "multipart/form-data";
 
   public final static String CHARSET_UTF_8 = "UTF-8";
   public static final String METHOD_GET = "GET";
   public static final String METHOD_POST = "POST";
   public static final String HEADER_ACCEPT = "Accept";
+
+  public static String getParameter( HttpServletRequest request, String name ) {
+    // Note: Using getParameter directly in Tomcat 11 will parse the request body.
+    // File upload requests will failed in this case as the request body is already processed.
+    if( CONTENT_TYPE_MULTIPART.equals( getMediaType( request.getContentType() ) ) ) {
+      return getQueryStringParameter( request, name );
+    }
+    return request.getParameter( name );
+  }
+
+  public static String getQueryStringParameter( HttpServletRequest request, String name ) {
+    String queryString = request.getQueryString();
+    if( queryString != null ) {
+      Map<String, List<String>> parameterMap = getParameterMap( queryString );
+      List<String> parameter = parameterMap.get( name );
+      if( parameter != null ) {
+        return parameter.get( 0 );
+      }
+    }
+    return null;
+  }
+
+  public static Map<String, List<String>> getParameterMap( String queryString ) {
+    Map<String, List<String>> parametersMap = new LinkedHashMap<>();
+    try {
+      String[] pairs = queryString.split( "&" );
+      for( String pair : pairs ) {
+        int idx = pair.indexOf( "=" );
+        String key = idx > 0 ? decode( pair.substring( 0, idx ), CHARSET_UTF_8 ) : pair;
+        if( !parametersMap.containsKey( key ) ) {
+          parametersMap.put( key, new LinkedList<>() );
+        }
+        String value = null;
+        if( idx > 0 && pair.length() > idx + 1 ) {
+          value = decode( pair.substring( idx + 1 ), CHARSET_UTF_8 );
+        }
+        parametersMap.get( key ).add( value );
+      }
+    } catch ( @SuppressWarnings( "unused" ) UnsupportedEncodingException ex ) {
+      // should never happen
+    }
+    return parametersMap;
+  }
+
+  public static String getMediaType( String contentType ) {
+    String result = null;
+    if( contentType != null ) {
+      int semicolon = contentType.indexOf( ';' );
+      if( semicolon > -1 ) {
+        result = contentType.substring( 0, semicolon );
+      } else {
+        result = contentType;
+      }
+      result = result.trim().toLowerCase( Locale.ENGLISH );
+    }
+    return result;
+  }
 
   private HTTP() {
     // prevent instantiation

--- a/tests/org.eclipse.rap.fileupload.test/src/org/eclipse/rap/fileupload/test/FileUploadTestUtil.java
+++ b/tests/org.eclipse.rap.fileupload.test/src/org/eclipse/rap/fileupload/test/FileUploadTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 EclipseSource and others.
+ * Copyright (c) 2011, 2025 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -76,11 +76,14 @@ public final class FileUploadTestUtil {
     TestRequest request = Fixture.fakeNewRequest();
     request.setMethod( "POST" );
     request.setParameter( "servicehandler", "org.eclipse.rap.fileupload" );
+    String queryString = "servicehandler=org.eclipse.rap.fileupload";
     String boundary = "-----4711-----";
     String body = createMultipartBody( boundary, new FileData( content, contentType, fileName ) );
     if( token != null ) {
       request.setParameter( "token", token );
+      queryString += "&token=" + token;
     }
+    request.setQueryString( queryString );
     request.setBody( body );
     request.setContentType( "multipart/form-data; boundary=" + boundary );
   }
@@ -106,11 +109,14 @@ public final class FileUploadTestUtil {
     TestRequest request = Fixture.fakeNewRequest();
     request.setMethod( "POST" );
     request.setParameter( "servicehandler", "org.eclipse.rap.fileupload" );
+    String queryString = "servicehandler=org.eclipse.rap.fileupload";
     String boundary = "-----4711-----";
     String body = createMultipartBody( boundary, fileData );
     if( token != null ) {
       request.setParameter( "token", token );
+      queryString += "&token=" + token;
     }
+    request.setQueryString( queryString );
     request.setBody( body );
     request.setContentType( "multipart/form-data; boundary=" + boundary );
   }

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/util/HTTP_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/rap/rwt/internal/util/HTTP_Test.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    EclipseSource - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.rap.rwt.internal.util;
+
+import static org.eclipse.rap.rwt.internal.util.HTTP.getMediaType;
+import static org.eclipse.rap.rwt.internal.util.HTTP.getParameter;
+import static org.eclipse.rap.rwt.internal.util.HTTP.getParameterMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.rap.rwt.testfixture.internal.TestRequest;
+import org.junit.Test;
+
+
+public class HTTP_Test {
+
+  @Test
+  public void testGetMediaType() {
+    assertEquals( "application/json", getMediaType( "application/json" ) );
+    assertEquals( "multipart/form-data", getMediaType( "multipart/form-data; boundary=123" ) );
+  }
+
+  @Test
+  public void testGetMediaType_nullValue() {
+    assertNull( "application/json", getMediaType( null ) );
+  }
+
+  @Test
+  public void testGetMediaType_emptyValue() {
+    assertEquals( "", getMediaType( "" ) );
+  }
+
+  @Test
+  public void testGetParameterMap_singleValue() {
+    Map<String, List<String>> parameterMap = getParameterMap( "a=1&b=2&c=3" );
+    assertEquals( "1", parameterMap.get( "a" ).get( 0 ) );
+    assertEquals( "2", parameterMap.get( "b" ).get( 0 ) );
+    assertEquals( "3", parameterMap.get( "c" ).get( 0 ) );
+  }
+
+  @Test
+  public void testGetParameterMap_doubleValue() {
+    Map<String, List<String>> parameterMap = getParameterMap( "a=1&b=2&c=3&b&c=4" );
+    assertEquals( "3", parameterMap.get( "c" ).get( 0 ) );
+    assertEquals( "4", parameterMap.get( "c" ).get( 1 ) );
+  }
+
+  @Test
+  public void testGetParameterMap_doubleValueWithNull() {
+    Map<String, List<String>> parameterMap = getParameterMap( "a=1&b=2&c=3&b&c=4" );
+    assertEquals( "2", parameterMap.get( "b" ).get( 0 ) );
+    assertNull( parameterMap.get( "b" ).get( 1 ) );
+  }
+
+  @Test
+  public void testGetParameterMap_missing() {
+    Map<String, List<String>> parameterMap = getParameterMap( "a=1&b=2&c=3&b&c=4" );
+    assertNull( parameterMap.get( "e" ) );
+  }
+
+  @Test
+  public void testGetParameter_notMultipart_usesRequestGetParameter() {
+    TestRequest request = new TestRequest();
+    request.setContentType( HTTP.CONTENT_TYPE_JSON );
+    request.setParameter( "a", "1" );
+    request.setQueryString( "b=2" );
+
+    assertEquals( "1", getParameter( request, "a" ) );
+    assertNull( getParameter( request, "b" ) );
+  }
+
+  @Test
+  public void testGetParameter_multipart_usesRequestQueryString() {
+    TestRequest request = new TestRequest();
+    request.setContentType( HTTP.CONTENT_TYPE_MULTIPART );
+    request.setParameter( "a", "1" );
+    request.setQueryString( "b=2" );
+
+    assertNull( getParameter( request, "a" ) );
+    assertEquals( "2", getParameter( request, "b" ) );
+  }
+
+}

--- a/tests/org.eclipse.rap.rwt.testfixture/src/org/eclipse/rap/rwt/testfixture/internal/TestRequest.java
+++ b/tests/org.eclipse.rap.rwt.testfixture/src/org/eclipse/rap/rwt/testfixture/internal/TestRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 EclipseSource and others.
+ * Copyright (c) 2009, 2025 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,6 +64,7 @@ public final class TestRequest implements HttpServletRequest {
   private String scheme;
   private String serverName;
   private String contextPath;
+  private String queryString;
   private String requestURI;
   private String servletPath;
   private String pathInfo;
@@ -176,7 +177,11 @@ public final class TestRequest implements HttpServletRequest {
 
   @Override
   public String getQueryString() {
-    return null;
+    return queryString;
+  }
+
+  public void setQueryString( String queryString ) {
+    this.queryString = queryString;
   }
 
   @Override


### PR DESCRIPTION
With commit
https://github.com/apache/tomcat/commit/3f8a229be8cbdd99e718b1b72b5f9c0ea1421c23 using request#getParameter in Tomcat 11 will parse the request body. As a result the file upload is broken as the request body is already processed in RWTServlet by the getting connection/service handler id.

The fix is to manually parse the query string parameters for multipart requests and not using request#getParameter.