### PR TITLE
Introduce support for sandbox and srcdoc attributes in Browser.

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/remote/handler/BrowserHandler.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/remote/handler/BrowserHandler.js
@@ -25,6 +25,8 @@ rwt.remote.HandlerRegistry.add( "rwt.widgets.Browser", {
 
   properties : rwt.remote.HandlerUtil.extendControlProperties( [
     "url",
+    "sandbox",
+    "inline",
     "functionResult"
   ] ),
 
@@ -36,6 +38,12 @@ rwt.remote.HandlerRegistry.add( "rwt.widgets.Browser", {
           widget.syncSource();
         }, 0 );
       }
+    },
+    "sandbox" : function( widget, value ) {
+      widget.setSandbox( value );
+    },
+    "inline" : function( widget, value ) {
+      widget.setInline( value );
     },
     "functionResult" : function( widget, value ) {
       widget.setFunctionResult( value[ 0 ], value[ 1 ], value[ 2 ] );

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/RWT.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/RWT.java
@@ -578,6 +578,7 @@ public final class RWT {
    * </p>
    *
    * @see Control#setData(String,Object)
+   * @since 4.2
    */
   public static final String INLINE = "org.eclipse.rap.rwt.inline";
   
@@ -600,6 +601,7 @@ public final class RWT {
    * </p>
    *
    * @see Control#setData(String,Object)
+   * @since 4.2
    */
   public static final String SANDBOX = "org.eclipse.rap.rwt.sandbox";
 

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/RWT.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/RWT.java
@@ -558,6 +558,50 @@ public final class RWT {
    * @since 2.2
    */
   public static final int CELL = 1 << 27;
+  
+  
+  /**
+   * Controls whether a document is embedded inline or as an external source (which is default behavior) in a <code>Browser</code>. For an inline document, this constant must be passed to <code>setData()</code>
+   * together with a value of <code>Boolean.TRUE</code>.
+   * <p>
+   * For example:
+   * <code><pre>
+   *   final Browser browser = new Browser( shell, SWT.BORDER );
+   *   browser.setData( RWT.INLINE, Boolean.TRUE );
+   *   browser.setText("&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;body&gt;&lt;p&gt;Inline document.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;");
+   * </pre></code>
+   * </p>
+   * <b>Used By:</b>
+   * <ul>
+   * <li><code>Browser</code></li>
+   * </ul>
+   * </p>
+   *
+   * @see Control#setData(String,Object)
+   */
+  public static final String INLINE = "org.eclipse.rap.rwt.inline";
+  
+  /**
+   * Controls the sandbox restrictions set to a <code>Browser</code>. This constant must be passed to <code>setData()</code>
+   * together with an <code>String</code> object. Pass the desired restrictions, or an empty <code>String</code> to apply all restrictions; pass <code>null</code> to remove previously set restrictions. 
+   * <p>
+   * For example:
+   * <code><pre>
+   *   final Browser browser = new Browser( shell, SWT.BORDER );
+   *   browser.setData( RWT.INLINE, Boolean.TRUE );
+   *   browser.setData( RWT.SANDBOX, "allow-scripts allow-modals" );
+   *   browser.setText("&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;body&gt;&lt;script type=&#39;text/javascript&#39;&gt;alert(&#39;Hello world!&#39;);&lt;/script&gt;&lt;/body&gt;&lt;/html&gt;");
+   * </pre></code>
+   * </p>
+   * <b>Used By:</b>
+   * <ul>
+   * <li><code>Browser</code></li>
+   * </ul>
+   * </p>
+   *
+   * @see Control#setData(String,Object)
+   */
+  public static final String SANDBOX = "org.eclipse.rap.rwt.sandbox";
 
   /**
    * Returns the instance of the resource manager for the current application context. This is a

--- a/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/browser/browserkit/BrowserLCA.java
+++ b/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/browser/browserkit/BrowserLCA.java
@@ -105,6 +105,9 @@ public final class BrowserLCA extends WidgetLCA<Browser> {
 
   private static void renderUrl( Browser browser ) throws IOException {
     if( hasUrlChanged( browser ) ) {
+      String restrictions = ( String )browser.getData( RWT.SANDBOX );
+      getRemoteObject( browser ).set( "sandbox", restrictions );
+      getRemoteObject( browser ).set( "inline", isInline( browser ) );
       getRemoteObject( browser ).set( "url", getUrl( browser ) );
       browser.getAdapter( IBrowserAdapter.class ).resetUrlChanged();
     }
@@ -120,7 +123,11 @@ public final class BrowserLCA extends WidgetLCA<Browser> {
     String url = browser.getUrl();
     String result;
     if( !"".equals( text.trim() ) ) {
-      result = registerHtml( text );
+      if( isInline( browser ) ) {
+        result = text;
+      } else {
+        result = registerHtml( text );
+      }
     } else if( !"".equals( url.trim() ) ) {
       result = url;
     } else {
@@ -168,6 +175,10 @@ public final class BrowserLCA extends WidgetLCA<Browser> {
     Object adapter = browser.getAdapter( IBrowserAdapter.class );
     IBrowserAdapter browserAdapter = ( IBrowserAdapter )adapter;
     return browserAdapter.getText();
+  }
+
+  private static boolean isInline( Browser browser ) {
+    return Boolean.TRUE.equals( browser.getData( RWT.INLINE ) );
   }
 
   //////////////////////////////////////

--- a/tests/org.eclipse.rap.rwt.jstest/js/org/eclipse/rwt/test/tests/BrowserTest.js
+++ b/tests/org.eclipse.rap.rwt.jstest/js/org/eclipse/rwt/test/tests/BrowserTest.js
@@ -26,6 +26,8 @@ rwt.qx.Class.define( "org.eclipse.rwt.test.tests.BrowserTest", {
 
     BLANK : "../rwt-resources/resource/static/html/blank.html",
     URL1 : "https://eclipsesource.com/",
+    SRCDOC : "<!DOCTYPE html><html><body><p>srcdoc</p></body></html>",
+    SANDBOX : "allow-scripts allow-modals",
 
     testCreateBrowserByProtocol : function() {
       var shell = TestUtil.createShellByProtocol( "w2" );
@@ -96,6 +98,78 @@ rwt.qx.Class.define( "org.eclipse.rwt.test.tests.BrowserTest", {
       },
       function( browser ) {
         assertEquals( this.URL1, browser.getSource() );
+        assertFalse( browser.getIframeNode().hasAttribute( "srcdoc" ) );
+        assertTrue( "slow connection?", browser._isLoaded );
+        browser.destroy();
+      }
+    ],
+
+	testSetSrcdocByProtocol : [
+	  function() {
+	    TestUtil.createShellByProtocol( "w2" );
+        Processor.processOperation( {
+          "target" : "w3",
+          "action" : "create",
+          "type" : "rwt.widgets.Browser",
+          "properties" : {
+            "style" : [],
+            "parent" : "w2"
+          }
+        } );
+        TestUtil.flush();
+
+        Processor.processOperation( {
+          "target" : "w3",
+          "action" : "set",
+          "properties" : {
+            "inline" : true,
+		    "url" : this.SRCDOC
+          }
+        } );
+
+        var browser = ObjectRegistry.getObject( "w3" );
+	    TestUtil.delayTest( 7000 );
+        TestUtil.store( browser );
+      },
+      function( browser ) {
+        assertEquals( this.SRCDOC, browser.getSource() );
+        assertEquals( this.SRCDOC, browser.getIframeNode().srcdoc );
+        assertFalse( browser.getIframeNode().hasAttribute( "src" ) );
+        assertTrue( "slow connection?", browser._isLoaded );
+        browser.destroy();
+      }
+    ],
+
+    testSetSandboxByProtocol : [
+      function() {
+        TestUtil.createShellByProtocol( "w2" );
+        Processor.processOperation( {
+          "target" : "w3",
+          "action" : "create",
+          "type" : "rwt.widgets.Browser",
+          "properties" : {
+            "style" : [],
+            "parent" : "w2"
+          }
+        } );
+        TestUtil.flush();
+
+        Processor.processOperation( {
+          "target" : "w3",
+          "action" : "set",
+          "properties" : {
+            "inline" : true,
+            "sandbox" : this.SANDBOX,
+            "url" : this.SRCDOC
+          }
+        } );
+
+        var browser = ObjectRegistry.getObject( "w3" );
+        TestUtil.delayTest( 7000 );
+        TestUtil.store( browser );
+      },
+      function( browser ) {
+        assertEquals( this.SANDBOX, browser.getIframeNode().sandbox.value );
         assertTrue( "slow connection?", browser._isLoaded );
         browser.destroy();
       }

--- a/tests/org.eclipse.rap.rwt.jstest/js/org/eclipse/rwt/test/tests/BrowserTest.js
+++ b/tests/org.eclipse.rap.rwt.jstest/js/org/eclipse/rwt/test/tests/BrowserTest.js
@@ -104,9 +104,9 @@ rwt.qx.Class.define( "org.eclipse.rwt.test.tests.BrowserTest", {
       }
     ],
 
-	testSetSrcdocByProtocol : [
-	  function() {
-	    TestUtil.createShellByProtocol( "w2" );
+    testSetSrcdocByProtocol : [
+      function() {
+        TestUtil.createShellByProtocol( "w2" );
         Processor.processOperation( {
           "target" : "w3",
           "action" : "create",
@@ -123,12 +123,12 @@ rwt.qx.Class.define( "org.eclipse.rwt.test.tests.BrowserTest", {
           "action" : "set",
           "properties" : {
             "inline" : true,
-		    "url" : this.SRCDOC
+            "url" : this.SRCDOC
           }
         } );
 
         var browser = ObjectRegistry.getObject( "w3" );
-	    TestUtil.delayTest( 7000 );
+        TestUtil.delayTest( 7000 );
         TestUtil.store( browser );
       },
       function( browser ) {


### PR DESCRIPTION
Proposing support for setting sandbox and srcdoc attributes of the iframe that represents the Browser widget in RWT.
- It would be good to have the possibility to configure the sandbox attribute of the iframe, regarding security aspects.
- Allowing usage of srcdoc attribute provides an alternative to external static files or larger data urls.

Configuration is done using setData with respective RWT constants.