### PR TITLE
Do not execute already disposed BrowserFunction

### DIFF
--- a/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/browser/browserkit/BrowserOperationHandler.java
+++ b/bundles/org.eclipse.rap.rwt/widgetkits/org/eclipse/swt/internal/browser/browserkit/BrowserOperationHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource and others.
+ * Copyright (c) 2013, 2025 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,9 @@ public class BrowserOperationHandler extends ControlOperationHandler<Browser> {
       ProcessActionRunner.add( new Runnable() {
         @Override
         public void run() {
-          executeFunction( browser, function, arguments );
+          if( !function.isDisposed() ) {
+            executeFunction( browser, function, arguments );
+          }
         }
       } );
     }


### PR DESCRIPTION
The execution of the `BrowserFunction` is delayed as it's executed in a `ProcessActionRunner`. It's possible to dispose the function before it's actually executed.

Issue: https://github.com/eclipse-rap/org.eclipse.rap/issues/274