### PR TITLE
Check that cell isn't null before invoking processTraverseEvent

### DIFF
--- a/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/viewers/ColumnViewerEditor.java
+++ b/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/viewers/ColumnViewerEditor.java
@@ -248,7 +248,7 @@ public abstract class ColumnViewerEditor implements Serializable {
 					tabeditingListener = new TraverseListener() {
 
 						public void keyTraversed(TraverseEvent e) {
-							if ((feature & DEFAULT) != DEFAULT && e.doit) {
+							if ((feature & DEFAULT) != DEFAULT && e.doit && cell != null) {
 								processTraverseEvent(cell.getColumnIndex(),
 										viewer.getViewerRowFromItem(cell
 												.getItem()), e);


### PR DESCRIPTION
Fix: https://github.com/eclipse-rap/org.eclipse.rap/issues/282