### PR TITLE
Add missing source bundles to SDK features

### DIFF
--- a/features/org.eclipse.rap.e4.sdk.feature/feature.xml
+++ b/features/org.eclipse.rap.e4.sdk.feature/feature.xml
@@ -149,4 +149,18 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.rap.servletbridge.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.rap.http.servletbridge.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/org.eclipse.rap.sdk.feature/feature.xml
+++ b/features/org.eclipse.rap.sdk.feature/feature.xml
@@ -135,4 +135,18 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.rap.servletbridge.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.rap.http.servletbridge.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
With the migration to Jakarta EE namespace, two additional bundles were moved into the RAP project. Add them to the SDK features in order to make the sources available.

- org.eclipse.rap.servletbridge
- org.eclipse.rap.http.servletbridge