### PR TITLE
Hide action bar chevron button if not used

### DIFF
--- a/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/action/ToolBarContributionItem.java
+++ b/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/action/ToolBarContributionItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     EclipseSource - ongoing development
  *******************************************************************************/
 
 package org.eclipse.jface.action;
@@ -41,7 +42,7 @@ import org.eclipse.swt.widgets.ToolItem;
  * <p>
  * This class may be instantiated; it is not intended to be subclassed.
  * </p>
- * 
+ *
  * @since 1.0
  * @noextend This class is not intended to be subclassed by clients.
  */
@@ -106,7 +107,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Convenience method equivalent to <code>ToolBarContributionItem(toolBarManager, null)</code>.
-     * 
+     *
      * @param toolBarManager
      *            the tool bar manager
      */
@@ -116,7 +117,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Creates a tool bar contribution item.
-     * 
+     *
      * @param toolBarManager
      *            the tool bar manager to wrap
      * @param id
@@ -132,10 +133,10 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
      * Checks whether this contribution item has been disposed. If it has, and
      * the tracing options are active, then it prints some debugging
      * information.
-     * 
+     *
      * @return <code>true</code> if the item is disposed; <code>false</code>
      *         otherwise.
-     *  
+     *
      */
     private final boolean checkDisposed() {
         if (disposed) {
@@ -153,7 +154,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.eclipse.jface.action.IContributionItem#dispose()
      */
     public void dispose() {
@@ -178,7 +179,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.eclipse.jface.action.IContributionItem#fill(org.eclipse.swt.widgets.CoolBar,
      *      int)
      */
@@ -197,9 +198,10 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
             // Do not create a coolItem if the toolbar is empty
             if (toolBar.getItemCount() < 1) {
-				return;
-			}
-            int flags = SWT.DROP_DOWN;
+                return;
+            }
+            // RAP: Hide chevron if not used
+            int flags = getUseChevron() ? SWT.DROP_DOWN : SWT.NONE;
             if (index >= 0) {
                 coolItem = new CoolItem(coolBar, flags, index);
             } else {
@@ -214,16 +216,16 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
             // ToolBarManager.createControl can actually return a pre-existing control.
             // Only add the listener if the toolbar was newly created (bug 62097).
             if (oldToolBar != toolBar) {
-	            toolBar.addListener(SWT.MenuDetect, new Listener() {
-	
-	                public void handleEvent(Event event) {
-	                    // if the toolbar does not have its own context menu then
-	                    // handle the event
-	                    if (toolBarManager.getContextMenuManager() == null) {
-	                        handleContextMenu(event);
-	                    }
-	                }
-	            });
+              toolBar.addListener(SWT.MenuDetect, new Listener() {
+
+                  public void handleEvent(Event event) {
+                      // if the toolbar does not have its own context menu then
+                      // handle the event
+                      if (toolBarManager.getContextMenuManager() == null) {
+                          handleContextMenu(event);
+                      }
+                  }
+              });
             }
 
             // Handle for chevron clicking
@@ -278,7 +280,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Returns the current height of the corresponding cool item.
-     * 
+     *
      * @return the current height
      */
     public int getCurrentHeight() {
@@ -290,7 +292,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Returns the current width of the corresponding cool item.
-     * 
+     *
      * @return the current size
      */
     public int getCurrentWidth() {
@@ -302,7 +304,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Returns the minimum number of tool items to show in the cool item.
-     * 
+     *
      * @return the minimum number of tool items to show, or <code>SHOW_ALL_ITEMS</code>
      *         if a value was not set
      * @see #setMinimumItemsToShow(int)
@@ -316,7 +318,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Returns the internal tool bar manager of the contribution item.
-     * 
+     *
      * @return the tool bar manager, or <code>null</code> if one is not
      *         defined.
      * @see IToolBarManager
@@ -330,7 +332,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Returns whether chevron support is enabled.
-     * 
+     *
      * @return <code>true</code> if chevron support is enabled, <code>false</code>
      *         otherwise
      */
@@ -396,7 +398,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
     /**
      * Handles the event when the toobar item does not have its own context
      * menu.
-     * 
+     *
      * @param event
      *            the event object
      */
@@ -426,7 +428,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /**
      * Handles the disposal of the widget.
-     * 
+     *
      * @param event
      *            the event object
      */
@@ -438,7 +440,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
      * A contribution item is visible iff its internal state is visible <em>or</em>
      * the tool bar manager contains something other than group markers and
      * separators.
-     * 
+     *
      * @return <code>true</code> if the tool bar manager contains something
      *         other than group marks and separators, and the internal state is
      *         set to be visible.
@@ -466,7 +468,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.eclipse.jface.action.IContributionItem#saveWidgetState()
      */
     public void saveWidgetState() {
@@ -474,8 +476,8 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
             return;
         }
         if (coolItem == null) {
-			return;
-		}
+            return;
+        }
 
         //1. Save current size
         CoolBar coolBar = coolItem.getParent();
@@ -517,7 +519,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
     /**
      * Sets the current height of the cool item. Update(SIZE) should be called
      * to adjust the widget.
-     * 
+     *
      * @param currentHeight
      *            the current height to set
      */
@@ -531,7 +533,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
     /**
      * Sets the current width of the cool item. Update(SIZE) should be called
      * to adjust the widget.
-     * 
+     *
      * @param currentWidth
      *            the current width to set
      */
@@ -547,7 +549,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
      * number is less than the total tool items, a chevron will appear and the
      * hidden tool items appear in a drop down menu. By default, all the tool
      * items are shown in the cool item.
-     * 
+     *
      * @param minimumItemsToShow
      *            the minimum number of tool items to show.
      * @see #getMinimumItemsToShow()
@@ -563,7 +565,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
     /**
      * Enables or disables chevron support for the cool item. By default,
      * chevron support is enabled.
-     * 
+     *
      * @param value
      *            <code>true</code> to enable chevron support, <code>false</code>
      *            otherwise.
@@ -577,7 +579,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.eclipse.jface.action.IContributionItem#update(java.lang.String)
      */
     public void update(String propertyName) {
@@ -600,7 +602,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
     /**
      * Updates the cool items' preferred, minimum, and current size. The
      * preferred size is calculated based on the tool bar size and extra trim.
-     * 
+     *
      * @param changeCurrentSize
      *            <code>true</code> if the current size should be changed to
      *            the preferred size, <code>false</code> to not change the


### PR DESCRIPTION
In the original JFace code the chevron button is always visible, but the selection listener is not added to the chevron if not used. This is confusing for the users as there is an UI element that is highlighed, clickable, but without any real response.