### PR TITLE
Remove event listeners when shell is destroyed

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/widgets/Shell.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/widgets/Shell.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2016 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2025 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -173,6 +173,9 @@ rwt.qx.Class.define( "rwt.widgets.Shell", {
   members : {
 
     destroy : function() {
+      this.removeEventListener( "changeActiveChild", this._onChangeActiveChild );
+      this.removeEventListener( "changeFocusedChild", this._onChangeFocusedChild );
+      this.removeEventListener( "changeActive", this._onChangeActive );
       this.doClose();
       this.getWindowManager().remove( this );
       this.base( arguments );


### PR DESCRIPTION
If you dispose the Shell on mouse click event, but you double clicked, the second event ends up on already disposed shell.