### PR TITLE
Upgrade to Tycho 4.0.13, replacer 1.5.3, remove deprecated configuration

### DIFF
--- a/bundles/org.eclipse.e4.core.commands/pom.xml
+++ b/bundles/org.eclipse.e4.core.commands/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <archiveSite>true</archiveSite>
           <format>'rap-'yyyyMMdd-HHmm</format>
         </configuration>
       </plugin>

--- a/bundles/org.eclipse.e4.emf.xpath/pom.xml
+++ b/bundles/org.eclipse.e4.emf.xpath/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <archiveSite>true</archiveSite>
           <format>'rap-'yyyyMMdd-HHmm</format>
         </configuration>
       </plugin>

--- a/bundles/org.eclipse.e4.ui.bindings/pom.xml
+++ b/bundles/org.eclipse.e4.ui.bindings/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <archiveSite>true</archiveSite>
           <format>'rap-'yyyyMMdd-HHmm</format>
         </configuration>
       </plugin>

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <archiveSite>true</archiveSite>
           <format>'rap-'yyyyMMdd-HHmm</format>
         </configuration>
       </plugin>

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <archiveSite>true</archiveSite>
           <format>'rap-'yyyyMMdd-HHmm</format>
         </configuration>
       </plugin>

--- a/bundles/org.eclipse.e4.ui.workbench.swt/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <archiveSite>true</archiveSite>
           <format>'rap-'yyyyMMdd-HHmm</format>
         </configuration>
       </plugin>

--- a/bundles/org.eclipse.e4.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <archiveSite>true</archiveSite>
           <format>'rap-'yyyyMMdd-HHmm</format>
         </configuration>
       </plugin>

--- a/releng/org.eclipse.rap.build/pom.xml
+++ b/releng/org.eclipse.rap.build/pom.xml
@@ -22,7 +22,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-    <tycho.version>3.0.4</tycho.version>
+    <tycho.version>4.0.13</tycho.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-rap/org.eclipse.rap</tycho.scmUrl>
     <!-- disabled due to bug 393977
     <tycho-baseline-repo.url>http://download.eclipse.org/rt/rap/3.2/</tycho-baseline-repo.url>

--- a/releng/org.eclipse.rap.examples.build/controlsdemo/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/controlsdemo/pom.xml
@@ -50,7 +50,7 @@
 
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>maven-replacer-plugin</artifactId>
+        <artifactId>replacer</artifactId>
         <version>${replacer.version}</version>
         <executions>
           <execution>
@@ -61,7 +61,7 @@
           </execution>
         </executions>
         <configuration>
-          <file>target/products/${project.artifactId}/linux/gtk/x86_64/configuration/config.ini</file>
+          <file>${project.build.directory}/products/${project.artifactId}/linux/gtk/x86_64/configuration/config.ini</file>
           <replacements>
             <replacement>
               <token>osgi.bundles=</token>

--- a/releng/org.eclipse.rap.examples.build/parent/parent/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/parent/parent/pom.xml
@@ -12,10 +12,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tycho.version>3.0.4</tycho.version>
+    <tycho.version>4.0.13</tycho.version>
     <tycho.showEclipseLog>true</tycho.showEclipseLog>
-    <assembly.version>3.3.0</assembly.version>
-    <replacer.version>1.4.1</replacer.version>
+    <assembly.version>3.7.1</assembly.version>
+    <replacer.version>1.5.3</replacer.version>
     <rap-repo.url>https://ci.eclipse.org/rap/job/rap-head-runtime-signed/lastSuccessfulBuild/artifact/org.eclipse.rap/releng/org.eclipse.rap.build/repository/target/repository/</rap-repo.url>
     <rap-incubator-repo.url>https://download.eclipse.org/rt/rap/incubator/nightly/</rap-incubator-repo.url>
   </properties>
@@ -60,7 +60,6 @@
         <artifactId>target-platform-configuration</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <resolver>p2</resolver>
           <environments>
             <environment>
               <os>linux</os>

--- a/releng/org.eclipse.rap.examples.build/rapdemo/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/rapdemo/pom.xml
@@ -50,7 +50,7 @@
 
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>maven-replacer-plugin</artifactId>
+        <artifactId>replacer</artifactId>
         <version>${replacer.version}</version>
         <executions>
           <execution>
@@ -61,7 +61,7 @@
           </execution>
         </executions>
         <configuration>
-          <file>target/products/${project.artifactId}/linux/gtk/x86_64/configuration/config.ini</file>
+          <file>${project.build.directory}/products/${project.artifactId}/linux/gtk/x86_64/configuration/config.ini</file>
           <replacements>
             <replacement>
               <token>osgi.bundles=</token>

--- a/releng/org.eclipse.rap.examples.build/workbenchdemo/pom.xml
+++ b/releng/org.eclipse.rap.examples.build/workbenchdemo/pom.xml
@@ -50,7 +50,7 @@
 
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>maven-replacer-plugin</artifactId>
+        <artifactId>replacer</artifactId>
         <version>${replacer.version}</version>
         <executions>
           <execution>
@@ -61,7 +61,7 @@
           </execution>
         </executions>
         <configuration>
-          <file>target/products/${project.artifactId}/linux/gtk/x86_64/configuration/config.ini</file>
+          <file>${project.build.directory}/products/${project.artifactId}/linux/gtk/x86_64/configuration/config.ini</file>
           <replacements>
             <replacement>
               <token>osgi.bundles=</token>


### PR DESCRIPTION
- Bumped Tycho version from 3.0.4 to 4.0.13
- Replaced deprecated archiveSite configuration in tycho-packaging-plugin
- Removed deprecated resolver parameter from target-platform-configuration
- Updated maven-replacer-plugin to replacer 1.5.3 and adapted file paths to use ${project.build.directory} for compatibility with newer versions
- Upgraded maven-assembly-plugin to 3.7.1 for consistency with newer toolchain