### PR TITLE
Fix Chrome error messages in JS console

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/runtime/System.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/runtime/System.js
@@ -33,7 +33,9 @@ rwt.qx.Class.define( "rwt.runtime.System", {
       this._onunloadWrapped = rwt.util.Functions.bind( this._onunload, this );
       window.addEventListener( "load", this._onloadWrapped, false );
       window.addEventListener( "beforeunload", this._onbeforeunloadWrapped, false );
-      window.addEventListener( "unload", this._onunloadWrapped, false );
+      var unloadEventName = rwt.client.Client.isBlink() ? "pagehide" : "unload";
+      // See: https://developer.chrome.com/docs/web-platform/deprecating-unload
+      window.addEventListener( unloadEventName, this._onunloadWrapped, false );
       rwt.event.EventHandler.setAllowContextMenu( rwt.widgets.Menu.getAllowContextMenu );
     }
   },
@@ -177,7 +179,9 @@ rwt.qx.Class.define( "rwt.runtime.System", {
   destruct : function() {
     window.removeEventListener( "load", this._onloadWrapped, false );
     window.removeEventListener( "beforeunload", this._onbeforeunloadWrapped, false );
-    window.removeEventListener( "unload", this._onunloadWrapped, false );
+    var unloadEventName = rwt.client.Client.isBlink() ? "pagehide" : "unload";
+    // See: https://developer.chrome.com/docs/web-platform/deprecating-unload
+    window.removeEventListener( unloadEventName, this._onunloadWrapped, false );
   },
 
   defer : function( statics )  {

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/rwt-index.html
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/service/rwt-index.html
@@ -3,7 +3,7 @@
   <head>
     <title>${title}</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="viewport" content="initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0" >
     <!-- IE9 render in standard mode, all older versions in quirksmode -->
     <meta http-equiv="X-UA-Compatible" content="IE=9,10,11;" >


### PR DESCRIPTION
- the meta "apple-mobile-web-app-capable" is replaced with "mobile-web-app-capable"
- page "unload" event is replaced with "pagehide" due to deprecation [1]

[1] https://developer.chrome.com/docs/web-platform/deprecating-unload

Fix: https://github.com/eclipse-rap/org.eclipse.rap/issues/315