### PR TITLE
Fix NPE in AbstractTableViewer handleDispose method

### DIFF
--- a/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
+++ b/bundles/org.eclipse.rap.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
@@ -230,7 +230,9 @@ public abstract class AbstractTableViewer extends ColumnViewer {
 
 	protected void handleDispose(DisposeEvent event) {
 		super.handleDispose(event);
-		virtualManager.dispose();
+		if (virtualManager != null) {
+		  virtualManager.dispose();
+		}
 		virtualManager = null;
 	}
 


### PR DESCRIPTION
In case of non virtual table AbstractTableViewer virtualManager has never been created. Prevent calling "dispose" on null virtualManager.