### PR TITLE
Add missing protected methods to Widget class

### DIFF
--- a/bundles/org.eclipse.rap.rwt/.settings/.api_filters
+++ b/bundles/org.eclipse.rap.rwt/.settings/.api_filters
@@ -43,11 +43,16 @@
         </filter>
     </resource>
     <resource path="src/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="See bug 334028" id="643842064">
+        <filter comment="Deprecation and marked for removal of SWTEventListener" id="338792546">
             <message_arguments>
-                <message_argument value="SWTEventListener"/>
-                <message_argument value="TypedListener"/>
+                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
                 <message_argument value="getEventListener()"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Deprecation and marked for removal of SWTEventListener" id="388161617">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+                <message_argument value="eventListener"/>
             </message_arguments>
         </filter>
         <filter comment="See bug 334028" id="643850349">

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/EventTable.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/EventTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.widgets;
+
+import java.util.EventListener;
 
 import org.eclipse.rap.rwt.scripting.ClientListener;
 import org.eclipse.swt.SWT;
@@ -170,7 +172,7 @@ class EventTable implements SerializableCompatibility {
     }
   }
 
-  public void unhook( int eventType, SWTEventListener listener ) {
+  public void unhook( int eventType, EventListener listener ) {
     if( types == null ) {
       return;
     }

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/TypedListener.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/TypedListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
+
+import java.util.EventListener;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ArmEvent;
@@ -68,7 +70,7 @@ public class TypedListener implements Listener {
 	/**
 	 * The receiver's event listener
 	 */
-	protected SWTEventListener eventListener;
+	protected EventListener eventListener;
 
 /**
  * Constructs a new instance of this class for the given event listener.
@@ -86,6 +88,24 @@ public TypedListener (SWTEventListener listener) {
 }
 
 /**
+ * Constructs a new instance of this class for the given event listener.
+ * <p>
+ * <b>IMPORTANT:</b> This method is <em>not</em> part of the SWT
+ * public API. It is marked public only so that it can be shared
+ * within the packages provided by SWT. It should never be
+ * referenced from application code.
+ * </p>
+ *
+ * @param listener the event listener to store in the receiver
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ */
+
+public TypedListener (EventListener listener) {
+    eventListener = listener;
+}
+
+/**
  * Returns the receiver's event listener.
  * <p>
  * <b>IMPORTANT:</b> This method is <em>not</em> part of the SWT
@@ -95,8 +115,9 @@ public TypedListener (SWTEventListener listener) {
  * </p>
  *
  * @return the receiver's event listener
+ * @since 4.5
  */
-public SWTEventListener getEventListener () {
+public EventListener getEventListener () {
 	return eventListener;
 }
 

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/TypedListener_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/TypedListener_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 EclipseSource and others.
+ * Copyright (c) 2012, 2025 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.EventListener;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ArmEvent;
@@ -73,7 +75,7 @@ public class TypedListener_Test {
     SWTEventListener listener = mock( SWTEventListener.class );
     TypedListener typedListener = new TypedListener( listener );
 
-    SWTEventListener eventListener = typedListener.getEventListener();
+    EventListener eventListener = typedListener.getEventListener();
 
     assertSame( listener, eventListener );
   }


### PR DESCRIPTION
In SWT the SWTEventListener is marked for deletion. To keep compatibility with the latest Eclipse Platform copy from SWT some protected methods in Widget class:

- removeListener( int eventType, EventListener listener )
- addTypedListener( EventListener listener, int... eventTypes )
- removeTypedListener( int eventType, EventListener listener )
- getTypedListeners( int eventType, Class<L> listenerType )

Additionally, TypedListener and EventTable classes now use EventListener instead of SWTEventListener.

See: https://github.com/eclipse-platform/eclipse.platform.swt/commit/2ce8542b0de0646ae186ada00f9623965690cacc

Issue: #342