### PR TITLE
Export client canvas internal package

### DIFF
--- a/bundles/org.eclipse.rap.rwt.addons/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.rwt.addons/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.rap.rwt.addons.camera;version="4.5.0",
  org.eclipse.rap.rwt.addons.canvas;version="4.5.0",
+ org.eclipse.rap.rwt.addons.internal.canvas;version="4.5.0";x-internal:=true,
  org.eclipse.rap.rwt.addons.scanner;version="4.5.0"

--- a/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/ClientCanvasOperator.java
+++ b/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/ClientCanvasOperator.java
@@ -18,10 +18,12 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.internal.widgets.canvaskit.CanvasOperationHandler;
 import org.eclipse.swt.widgets.Canvas;
 
-
+/**
+ * @since 4.5
+ */
 @SuppressWarnings({
-  "restriction",
-  "serial"
+  "serial",
+  "restriction"
 })
 public class ClientCanvasOperator extends CanvasOperationHandler {
 

--- a/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/ClientDrawListenerAdapter.java
+++ b/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/ClientDrawListenerAdapter.java
@@ -15,6 +15,9 @@ import java.util.Collection;
 
 import org.eclipse.rap.rwt.addons.canvas.ClientDrawListener;
 
+/**
+ * @since 4.5
+ */
 public class ClientDrawListenerAdapter {
 
   private final Collection<ClientDrawListener> drawListeners;

--- a/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/DrawingsCache.java
+++ b/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/DrawingsCache.java
@@ -14,6 +14,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @since 4.5
+ */
 @SuppressWarnings("serial")
 public class DrawingsCache implements Serializable {
 

--- a/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/GCOperationDispatcher.java
+++ b/bundles/org.eclipse.rap.rwt.addons/src/org/eclipse/rap/rwt/addons/internal/canvas/GCOperationDispatcher.java
@@ -19,6 +19,9 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Path;
 import org.eclipse.swt.graphics.RGB;
 
+/**
+ * @since 4.5
+ */
 @SuppressWarnings("serial")
 public class GCOperationDispatcher implements Serializable {
 


### PR DESCRIPTION
This is needed in order to access DrawingsCache class.