### PR TITLE
Require JavaSE-21 for all RAP bundles

### DIFF
--- a/bundles/org.eclipse.e4.core.commands/.classpath
+++ b/bundles/org.eclipse.e4.core.commands/.classpath
@@ -3,6 +3,6 @@
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="src-rap"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.e4.core.commands/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.core.commands/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Version: 0.11.0.qualifier
 Bundle-Activator: org.eclipse.e4.core.commands.internal.Activator
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.e4.core.commands/build.properties
+++ b/bundles/org.eclipse.e4.core.commands/build.properties
@@ -17,4 +17,4 @@ bin.includes = META-INF/,\
 source.. = src/,\
            src-rap/
 src.includes = about.html
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.e4.emf.xpath/.classpath
+++ b/bundles/org.eclipse.e4.emf.xpath/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-rap"/>

--- a/bundles/org.eclipse.e4.emf.xpath/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.emf.xpath/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.emf.xpath
 Bundle-Version: 0.4.300.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.35.0",
  org.eclipse.core.runtime;bundle-version="3.29.0",
  org.apache.commons.commons-beanutils;bundle-version="1.9.4"

--- a/bundles/org.eclipse.e4.emf.xpath/build.properties
+++ b/bundles/org.eclipse.e4.emf.xpath/build.properties
@@ -20,4 +20,4 @@ bin.includes = META-INF/,\
                OSGI-INF/
 src.includes = about_files/,\
                about.html
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.e4.ui.bindings/.classpath
+++ b/bundles/org.eclipse.e4.ui.bindings/.classpath
@@ -3,6 +3,6 @@
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="src-rap"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Version: 0.11.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.e4.ui.bindings/build.properties
+++ b/bundles/org.eclipse.e4.ui.bindings/build.properties
@@ -17,4 +17,4 @@ bin.includes = META-INF/,\
 source.. = src/,\
            src-rap/
 src.includes = about.html
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/.classpath
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/.classpath
@@ -3,6 +3,6 @@
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="src-rap"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.e4.ui.model.workbench;bundle-version="1.0.0",
  org.eclipse.rap.rwt;bundle-version="2.3.0",
  org.eclipse.rap.jface;bundle-version="2.3.0"
 Require-Capability: org.eclipse.rap;filter:="(org.eclipse.rap.rwt=true)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/build.properties
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/build.properties
@@ -19,4 +19,4 @@ bin.includes = META-INF/,\
                icons/
 src.includes = icons/,\
                about.html
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/.classpath
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/.classpath
@@ -2,6 +2,6 @@
 <classpath>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Version: 0.13.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.e4.ui.workbench;bundle-version="0.9.0",
  org.eclipse.e4.core.services;bundle-version="0.9.0",
  org.eclipse.e4.core.contexts;bundle-version="1.0.0",

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/build.properties
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/build.properties
@@ -17,4 +17,4 @@ bin.includes = META-INF/,\
                plugin.properties,\
                icons/
 src.includes = about.html
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.e4.ui.workbench.swt/.classpath
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-rap"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
@@ -30,7 +30,7 @@ Require-Bundle: org.eclipse.equinox.registry;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.e4.core.di.extensions
 Require-Capability: org.eclipse.rap;filter:="(org.eclipse.rap.rwt=true)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.e4.ui.internal.workbench.swt;x-friends:="org.eclipse.e4.ui.workbench.addons.swt,org.eclipse.e4.ui.workbench.renderers.swt,org.eclipse.ui.workbench",
  org.eclipse.e4.ui.internal.workbench.swt.handlers;x-internal:=true,
  org.eclipse.e4.ui.workbench.swt.factories;x-friends:="org.eclipse.e4.ui.workbench.renderers.swt,org.eclipse.ui.workbench",

--- a/bundles/org.eclipse.e4.ui.workbench.swt/build.properties
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/build.properties
@@ -21,4 +21,4 @@ source.. = src/,\
            src-rap/
 src.includes = icons/,\
                about.html
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.e4.ui.workbench/.classpath
+++ b/bundles/org.eclipse.e4.ui.workbench/.classpath
@@ -3,6 +3,6 @@
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="src-rap"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.e4.ui.model.workbench;bundle-version="1.0.0",
  org.eclipse.e4.core.di.extensions
 Require-Capability: org.eclipse.rap;filter:="(org.eclipse.rap.rwt=true)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.e4.ui.internal.workbench;
   x-friends:="org.eclipse.e4.ui.workbench.fragment,
    org.eclipse.e4.ui.workbench.renderers.swt,

--- a/bundles/org.eclipse.e4.ui.workbench/build.properties
+++ b/bundles/org.eclipse.e4.ui.workbench/build.properties
@@ -20,4 +20,4 @@ src.includes = schema/,\
                about.html
 source.. = src/,\
            src-rap/
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.rap.e4/.classpath
+++ b/bundles/org.eclipse.rap.e4/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.e4/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.e4/META-INF/MANIFEST.MF
@@ -30,4 +30,4 @@ Export-Package: org.eclipse.rap.e4;version="4.6.0",
  org.eclipse.rap.e4.preferences;version="4.6.0"
 Service-Component: OSGI-INF/rapeventbroker.xml,OSGI-INF/rapeventobjectsupplier.xml,OSGI-INF/rapuieventobjectsupplier.xml,OSGI-INF/rappreferenceobjectsupplier.xml,
  OSGI-INF/preferenceserviceCF.xml,OSGI-INF/raptranslationobjectsupplier.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/bundles/org.eclipse.rap.e4/build.properties
+++ b/bundles/org.eclipse.rap.e4/build.properties
@@ -19,4 +19,4 @@ jars.compile.order = .
 source.. = src/
 output.. = bin/
 src.includes = about.html
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/bundles/org.eclipse.rap.filedialog/.classpath
+++ b/bundles/org.eclipse.rap.filedialog/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.filedialog/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.filedialog/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.rap.filedialog
 Bundle-Version: 4.6.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",

--- a/bundles/org.eclipse.rap.fileupload/.classpath
+++ b/bundles/org.eclipse.rap.fileupload/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.fileupload/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.fileupload/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.rap.fileupload;singleton:=true
 Bundle-Version: 4.6.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)"

--- a/bundles/org.eclipse.rap.http.jetty/.classpath
+++ b/bundles/org.eclipse.rap.http.jetty/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.http.jetty/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.http.jetty/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Import-Package: jakarta.servlet;version="[5.0.0,7.0.0)",
  org.osgi.framework.startlevel;version="1.0.0",
  org.osgi.framework.wiring;version="1.2.0",
  org.osgi.service.cm;version="1.2.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.rap.http.jetty;version="4.6.0"
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.rap.http.jetty

--- a/bundles/org.eclipse.rap.http.registry/.classpath
+++ b/bundles/org.eclipse.rap.http.registry/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.http.registry/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.http.registry/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Import-Package: jakarta.servlet;version="[5.0.0,7.0.0)",
  org.eclipse.rap.service.http;version="[4.6.0,5.0.0)",
  org.osgi.service.packageadmin;version="1.2.0",
  org.osgi.util.tracker;version="1.3.1"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.rap.http.registry;version="1.0.0"
 Bundle-Vendor: %providerName
 Automatic-Module-Name: org.eclipse.rap.http.registry

--- a/bundles/org.eclipse.rap.http.servlet/.classpath
+++ b/bundles/org.eclipse.rap.http.servlet/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/org.eclipse.rap.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.http.servlet/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.eclipse.rap.http.servlet
 Bundle-Version: 4.6.0.qualifier
 Bundle-Activator: org.eclipse.rap.http.servlet.internal.Activator
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.rap.http.servlet;version="4.6.0",
  org.eclipse.rap.http.servlet.context;version="4.6.0";x-internal:=true,
  org.eclipse.rap.http.servlet.dto;version="4.6.0";x-internal:=true,

--- a/bundles/org.eclipse.rap.http.servletbridge/.classpath
+++ b/bundles/org.eclipse.rap.http.servletbridge/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.http.servletbridge/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.http.servletbridge/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Import-Package: jakarta.servlet.http;version="[5.0.0,7.0.0)",
  org.eclipse.rap.http.servlet;version="4.6.0",
  org.eclipse.rap.servletbridge;version="4.6.0",
  org.osgi.framework;version="1.3.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.rap.http.servletbridge

--- a/bundles/org.eclipse.rap.jface.databinding/.classpath
+++ b/bundles/org.eclipse.rap.jface.databinding/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.jface.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.jface.databinding/META-INF/MANIFEST.MF
@@ -27,4 +27,4 @@ Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.core.databinding.property;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.core.databinding;bundle-version="[1.3.0,2.0.0)"
 Import-Package: com.ibm.icu.text
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/bundles/org.eclipse.rap.jface/.classpath
+++ b/bundles/org.eclipse.rap.jface/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.jface/META-INF/MANIFEST.MF
@@ -38,7 +38,7 @@ Export-Package: org.eclipse.jface,
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)";visibility:=reexport,
  org.eclipse.core.commands;bundle-version="[3.4.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.common;bundle-version="[3.2.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: javax.xml.parsers,
  org.osgi.framework,
  org.w3c.dom,

--- a/bundles/org.eclipse.rap.nebula.jface.gridviewer/.classpath
+++ b/bundles/org.eclipse.rap.nebula.jface.gridviewer/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.nebula.jface.gridviewer/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.nebula.jface.gridviewer/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.nebula.jface.gridviewer
 Bundle-Version: 4.6.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.rap.nebula.widgets.grid;bundle-version="4.6.0",

--- a/bundles/org.eclipse.rap.nebula.widgets.grid/.classpath
+++ b/bundles/org.eclipse.rap.nebula.widgets.grid/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.rap.nebula.widgets.grid/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.nebula.widgets.grid/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.eclipse.rap.nebula.widgets.grid
 Bundle-Version: 4.6.0.qualifier
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)"
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.servlet;version="[5.0.0,7.0.0)",
  jakarta.servlet.http;version="[5.0.0,7.0.0)"
 Export-Package: org.eclipse.nebula.widgets.grid,

--- a/bundles/org.eclipse.rap.nebula.widgets.richtext/.classpath
+++ b/bundles/org.eclipse.rap.nebula.widgets.richtext/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.nebula.widgets.richtext/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.nebula.widgets.richtext/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.nebula.widgets.richtext
 Bundle-Version: 4.6.0.qualifier
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %Bundle-Vendor
 Import-Package: jakarta.servlet;version="[5.0.0,7.0.0)",
  jakarta.servlet.http;version="[5.0.0,7.0.0)"

--- a/bundles/org.eclipse.rap.rwt.addons/.classpath
+++ b/bundles/org.eclipse.rap.rwt.addons/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/org.eclipse.rap.rwt.addons/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.rwt.addons/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.rap.fileupload;bundle-version="[4.0.0,5.0.0)"
 Automatic-Module-Name: org.eclipse.rap.rwt.addons
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.rap.rwt.addons.camera;version="4.6.0",
  org.eclipse.rap.rwt.addons.canvas;version="4.6.0",
  org.eclipse.rap.rwt.addons.internal.canvas;version="4.6.0";x-internal:=true,

--- a/bundles/org.eclipse.rap.rwt.osgi/.classpath
+++ b/bundles/org.eclipse.rap.rwt.osgi/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.rwt.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.rwt.osgi/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.rap.rwt.osgi
 Bundle-Version: 4.6.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.servlet;version="[5.0.0,7.0.0)",
  jakarta.servlet.descriptor;version="[5.0.0,7.0.0)";resolution:=optional,
  jakarta.servlet.http;version="[5.0.0,7.0.0)",

--- a/bundles/org.eclipse.rap.rwt/.classpath
+++ b/bundles/org.eclipse.rap.rwt/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="src" path="widgetkits"/>

--- a/bundles/org.eclipse.rap.rwt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.rwt/META-INF/MANIFEST.MF
@@ -108,4 +108,4 @@ Export-Package: org.eclipse.rap.json;version="4.6.0",
  org.eclipse.swt.layout,
  org.eclipse.swt.widgets,
  org.w3c.css.sac;version="1.1.0";x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/bundles/org.eclipse.rap.servletbridge/.classpath
+++ b/bundles/org.eclipse.rap.servletbridge/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.servletbridge/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.servletbridge/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-Localization: plugin
 Import-Package: jakarta.servlet;version="[5.0.0,7.0.0)",
  jakarta.servlet.http;version="[5.0.0,7.0.0)"
 Export-Package: org.eclipse.rap.servletbridge;version="4.6.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.rap.servletbridge

--- a/bundles/org.eclipse.rap.ui.cheatsheets/.classpath
+++ b/bundles/org.eclipse.rap.ui.cheatsheets/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.ui.cheatsheets/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.ui.cheatsheets/META-INF/MANIFEST.MF
@@ -30,5 +30,5 @@ Import-Package: com.ibm.icu.text,
  javax.xml.parsers,
  org.w3c.dom,
  org.xml.sax
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.rap.ui.forms/.classpath
+++ b/bundles/org.eclipse.rap.ui.forms/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="rap"/>

--- a/bundles/org.eclipse.rap.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.ui.forms/META-INF/MANIFEST.MF
@@ -19,6 +19,6 @@ Import-Package: com.ibm.icu.text,
  javax.xml.parsers,
  org.w3c.dom,
  org.xml.sax
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/bundles/org.eclipse.rap.ui.views/.classpath
+++ b/bundles/org.eclipse.rap.ui.views/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.ui.views/META-INF/MANIFEST.MF
@@ -15,5 +15,5 @@ Export-Package: org.eclipse.ui.internal.views;x-internal:=true,
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.rap.ui;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.help;bundle-version="[3.2.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-LazyStart: true

--- a/bundles/org.eclipse.rap.ui.workbench/.classpath
+++ b/bundles/org.eclipse.rap.ui.workbench/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="Eclipse UI"/>
 	<classpathentry kind="src" path="Eclipse UI Editor Support"/>

--- a/bundles/org.eclipse.rap.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.ui.workbench/META-INF/MANIFEST.MF
@@ -116,4 +116,4 @@ Import-Package: com.ibm.icu.text,
  org.eclipse.rap.service.http;version="[4.6.0,5.0.0)",
  org.w3c.dom,
  org.xml.sax
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/bundles/org.eclipse.rap.ui/.classpath
+++ b/bundles/org.eclipse.rap.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.eclipse.rap.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rap.ui/META-INF/MANIFEST.MF
@@ -17,4 +17,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.rap.jface;bundle-version="[4.6.0,5.0.0)";visibility:=reexport,
  org.eclipse.rap.ui.workbench;bundle-version="[4.6.0,5.0.0)";visibility:=reexport,
  org.eclipse.core.expressions;bundle-version="[3.5.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/examples/org.eclipse.rap.demo.controls/.classpath
+++ b/examples/org.eclipse.rap.demo.controls/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.demo.controls/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.demo.controls/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.rap.demo.controls;singleton:=true
 Bundle-Version: 4.6.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.servlet.http;version="6.0.0",
  org.eclipse.core.runtime.jobs
 Export-Package: org.eclipse.rap.demo.controls;version="4.6.0",

--- a/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
+++ b/examples/org.eclipse.rap.demo.controls/launch/RAP Controls Demo.launch
@@ -21,7 +21,7 @@
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -clean -console -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Declipse.ignoreApp=true&#13;&#10;-Dosgi.noShutdown=true&#13;&#10;-Dorg.eclipse.equinox.http.jetty.log.stderr.threshold=info"/>

--- a/examples/org.eclipse.rap.demo.databinding/.classpath
+++ b/examples/org.eclipse.rap.demo.databinding/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.demo.databinding/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.demo.databinding/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.rap.jface.databinding;bundle-version="[4.6.0,5.0.0)"
  org.eclipse.core.databinding.beans,
  org.eclipse.core.databinding.property,
  org.eclipse.rap.ui;bundle-version="[4.6.0,5.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Export-Package: org.eclipse.rap.demo.databinding;version="4.6.0";x-internal:=true,
  org.eclipse.rap.demo.databinding.nestedselection;version="4.6.0";x-internal:=true

--- a/examples/org.eclipse.rap.demo/.classpath
+++ b/examples/org.eclipse.rap.demo/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.demo/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.demo/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.rap.ui;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.rap.ui.views;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.rap.ui.forms;bundle-version="[4.6.0,5.0.0)"
 Import-Package: jakarta.servlet.http;version="6.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.rap.demo;version="4.6.0";x-internal:=true,
  org.eclipse.rap.demo.actions;version="4.6.0";x-internal:=true,
  org.eclipse.rap.demo.editor;version="4.6.0";x-internal:=true,

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Business).launch
@@ -18,7 +18,7 @@
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -console -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.noShutdown=true -Declipse.ignoreApp=true&#13;&#10;-Dorg.eclipse.equinox.http.jetty.log.stderr.threshold=info"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (Fancy).launch
@@ -18,7 +18,7 @@
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -console -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.noShutdown=true -Declipse.ignoreApp=true&#13;&#10;-Dorg.eclipse.equinox.http.jetty.log.stderr.threshold=info"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo (OSGi).launch
@@ -15,7 +15,7 @@
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-console -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.osgi.service.http.port=9090&#13;&#10;-Dosgi.noShutdown=true&#13;&#10;-Declipse.ignoreApp=true"/>

--- a/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
+++ b/examples/org.eclipse.rap.demo/launch/RAP Workbench Demo.launch
@@ -18,7 +18,7 @@
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -console -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.noShutdown=true -Declipse.ignoreApp=true&#13;&#10;-Dorg.eclipse.equinox.http.jetty.log.stderr.threshold=info"/>

--- a/examples/org.eclipse.rap.design.example/.classpath
+++ b/examples/org.eclipse.rap.design.example/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.design.example/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.design.example/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.design.example;singleton:=true
 Bundle-Version: 4.6.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.rap.ui;bundle-version="[4.6.0,5.0.0)"
 Bundle-Localization: plugin
 Export-Package: org.eclipse.rap.internal.design.example;version="4.6.0";x-internal:=true,

--- a/examples/org.eclipse.rap.e4.demo/.classpath
+++ b/examples/org.eclipse.rap.e4.demo/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.e4.demo/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.e4.demo/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: RAP E4 Demo
 Bundle-SymbolicName: org.eclipse.rap.e4.demo
 Bundle-Version: 4.6.0.qualifier
 Bundle-Vendor: Eclipse.org - RAP
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.rap.e4;bundle-version="[4.6.0,5.0.0)",

--- a/examples/org.eclipse.rap.e4.demo/build.properties
+++ b/examples/org.eclipse.rap.e4.demo/build.properties
@@ -6,4 +6,4 @@ bin.includes = META-INF/,\
                Application.e4xmi,\
                icons/,\
                launch/
-jre.compilation.profile = JavaSE-17
+jre.compilation.profile = JavaSE-21

--- a/examples/org.eclipse.rap.e4.demo/launch/RAP e4 Demo.launch
+++ b/examples/org.eclipse.rap.e4.demo/launch/RAP e4 Demo.launch
@@ -19,7 +19,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -console -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Declipse.ignoreApp=true -Dosgi.noShutdown=true -Dorg.eclipse.equinox.http.jetty.log.stderr.threshold=info"/>

--- a/examples/org.eclipse.rap.examples.pages/.classpath
+++ b/examples/org.eclipse.rap.examples.pages/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.examples.pages/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.examples.pages/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.rap.examples.pages
 Bundle-Version: 4.6.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",

--- a/examples/org.eclipse.rap.examples/.classpath
+++ b/examples/org.eclipse.rap.examples/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.examples/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Activator: org.eclipse.rap.examples.internal.Activator
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Import-Package: jakarta.servlet;version="6.0.0",
  jakarta.servlet.http;version="6.0.0",

--- a/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
+++ b/examples/org.eclipse.rap.examples/launch/RAP Examples Demo.launch
@@ -21,7 +21,7 @@
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -clean -console -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Declipse.ignoreApp=true&#13;&#10;-Dosgi.noShutdown=true&#13;&#10;-Dorg.eclipse.equinox.http.jetty.log.stderr.threshold=info"/>

--- a/examples/org.eclipse.rap.filedialog.demo.examples/.classpath
+++ b/examples/org.eclipse.rap.filedialog.demo.examples/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.filedialog.demo.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.filedialog.demo.examples/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Version: 4.6.0.qualifier
 Bundle-SymbolicName: org.eclipse.rap.filedialog.demo.examples
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.servlet;version="6.0.0",
  jakarta.servlet.http;version="6.0.0",
  org.eclipse.rap.fileupload;version="[4.6.0,5.0.0)",

--- a/examples/org.eclipse.rap.nebula.widgets.grid.demo.examples/.classpath
+++ b/examples/org.eclipse.rap.nebula.widgets.grid.demo.examples/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.nebula.widgets.grid.demo.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.nebula.widgets.grid.demo.examples/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.rap.nebula.widgets.grid.demo.examples
 Bundle-Version: 4.6.0.qualifier
 Bundle-Activator: org.eclipse.rap.nebula.widget.grid.demo.examples.Activator
 Import-Package: org.osgi.framework;version="1.3.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="4.6.0",

--- a/examples/org.eclipse.rap.nebula.widgets.richtext.demo.examples/.classpath
+++ b/examples/org.eclipse.rap.nebula.widgets.richtext.demo.examples/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/org.eclipse.rap.nebula.widgets.richtext.demo.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.rap.nebula.widgets.richtext.demo.examples/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.nebula.widgets.richtext.demo.examples
 Bundle-Version: 4.6.0.qualifier
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Activator: org.eclipse.rap.nebula.widgets.richtext.demo.examples.Activator
 Import-Package: org.eclipse.nebula.widgets.richtext;version="[4.6.0,5.0.0)",

--- a/releng/org.eclipse.rap.clientbuilder/.classpath
+++ b/releng/org.eclipse.rap.clientbuilder/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test"/>

--- a/releng/org.eclipse.rap.clientbuilder/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.rap.clientbuilder/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: RAP JavaScript WebClient Builder
 Bundle-SymbolicName: org.eclipse.rap.clientbuilder
 Bundle-Version: 4.6.0.qualifier
 Bundle-Vendor: Eclipse.org - RAP
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.mozilla.rhino;bundle-version="[1.7.14,1.8.0)",
  org.junit;bundle-version="4.11.0";resolution:=optional
 Export-Package: org.eclipse.rap.clientbuilder;version="4.6.0"

--- a/releng/org.eclipse.rap.project.template/.classpath
+++ b/releng/org.eclipse.rap.project.template/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/releng/org.eclipse.rap.project.template/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.rap.project.template/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Project Settings Template
 Bundle-SymbolicName: org.eclipse.rap.project.template
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.rap.filedialog.test/.classpath
+++ b/tests/org.eclipse.rap.filedialog.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.filedialog.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.filedialog.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.filedialog.test
 Bundle-Version: 4.6.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",

--- a/tests/org.eclipse.rap.fileupload.test/.classpath
+++ b/tests/org.eclipse.rap.fileupload.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.fileupload.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.fileupload.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.rap.fileupload.test
 Bundle-Version: 4.6.0.qualifier
 Fragment-Host: org.eclipse.rap.fileupload;bundle-version="[4.6.0,5.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Import-Package: jakarta.servlet;version="[6.0.0,7.0.0)",

--- a/tests/org.eclipse.rap.nebula.widgets.grid.test/.classpath
+++ b/tests/org.eclipse.rap.nebula.widgets.grid.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.nebula.widgets.grid.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.nebula.widgets.grid.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.rap.nebula.widgets.grid.test
 Bundle-Version: 4.6.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit;bundle-version="4.8.2",
  net.bytebuddy.byte-buddy,
  net.bytebuddy.byte-buddy-agent

--- a/tests/org.eclipse.rap.nebula.widgets.richtext.test/.classpath
+++ b/tests/org.eclipse.rap.nebula.widgets.richtext.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="js"/>

--- a/tests/org.eclipse.rap.nebula.widgets.richtext.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.nebula.widgets.richtext.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.nebula.widgets.richtext.test
 Bundle-Version: 4.6.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Fragment-Host: org.eclipse.rap.nebula.widgets.richtext;bundle-version="4.6.0"
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",
  org.junit;bundle-version="4.8.1",

--- a/tests/org.eclipse.rap.rwt.addons.test/.classpath
+++ b/tests/org.eclipse.rap.rwt.addons.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/tests/org.eclipse.rap.rwt.addons.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.addons.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.rap.rwt.addons.test
 Bundle-Version: 4.6.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.rap.rwt.addons.test
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Fragment-Host: org.eclipse.rap.rwt.addons;bundle-version="4.6.0"
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)",
  org.junit;bundle-version="4.8.1",

--- a/tests/org.eclipse.rap.rwt.cluster.test/.classpath
+++ b/tests/org.eclipse.rap.rwt.cluster.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.rwt.cluster.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.cluster.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: RWT Cluster Tests
 Bundle-SymbolicName: org.eclipse.rap.rwt.cluster.test
 Bundle-Version: 4.1.0.qualifier
 Bundle-Vendor: Eclipse.org - RAP
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.1.0,5.0.0)",
  org.eclipse.rap.rwt.cluster.testfixture;bundle-version="[4.1.0,5.0.0)",
  org.junit;bundle-version="4.8.2"

--- a/tests/org.eclipse.rap.rwt.cluster.testfixture.test/.classpath
+++ b/tests/org.eclipse.rap.rwt.cluster.testfixture.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.rwt.cluster.testfixture.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.cluster.testfixture.test/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-Vendor: Eclipse.org - RAP
 Require-Bundle: org.junit;bundle-version="4.8.2"
 Import-Package: org.junit.runner;version="4.8.2",
  org.junit.runners;version="4.8.2"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.rap.rwt.cluster.testfixture/.classpath
+++ b/tests/org.eclipse.rap.rwt.cluster.testfixture/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.rwt.cluster.testfixture/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.cluster.testfixture/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Cluster Testfixture
 Bundle-SymbolicName: org.eclipse.rap.rwt.cluster.testfixture
 Bundle-Version: 4.1.0.qualifier
 Bundle-Vendor: Eclipse.org - RAP
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: javax.servlet;version="3.1.0",
  javax.servlet.http;version="3.1.0",
  org.apache.catalina;version="[7.0.0,8.0.0)",

--- a/tests/org.eclipse.rap.rwt.jstest/.classpath
+++ b/tests/org.eclipse.rap.rwt.jstest/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="js"/>
 	<classpathentry kind="src" path="src"/>

--- a/tests/org.eclipse.rap.rwt.jstest/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.jstest/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Export-Package: org.eclipse.rap.rwt.jstest,
  org.eclipse.rwt.test.fixture,
  org.eclipse.rwt.test.tests,
  resource
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.rap.http.jetty;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)"
 Import-Package: jakarta.servlet;version="6.0.0",

--- a/tests/org.eclipse.rap.rwt.jstest/RWT Client Tests.launch
+++ b/tests/org.eclipse.rap.rwt.jstest/RWT Client Tests.launch
@@ -19,7 +19,7 @@
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consolelog -console -clean"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Declipse.ignoreApp=true -Dosgi.noShutdown=true&#13;&#10;-Dorg.osgi.service.http.port=8081&#13;&#10;-Dorg.eclipse.rap.rwt.developmentMode=true"/>

--- a/tests/org.eclipse.rap.rwt.osgi.test/.classpath
+++ b/tests/org.eclipse.rap.rwt.osgi.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.rwt.osgi.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.osgi.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.rap.rwt.osgi.test
 Bundle-Version: 4.6.0.qualifier
 Bundle-Vendor: Eclipse.org - RAP
 Fragment-Host: org.eclipse.rap.rwt.osgi;bundle-version="4.6.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit;bundle-version="4.8.2",
  net.bytebuddy.byte-buddy,
  net.bytebuddy.byte-buddy-agent

--- a/tests/org.eclipse.rap.rwt.test/.classpath
+++ b/tests/org.eclipse.rap.rwt.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.rwt.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.test/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.junit;bundle-version="4.8.2",
  net.bytebuddy.byte-buddy,
  net.bytebuddy.byte-buddy-agent
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.servlet;version="6.0.0",
  jakarta.servlet.http;version="6.0.0",
  org.eclipse.rap.rwt.testfixture;version="[4.6.0,5.0.0)",

--- a/tests/org.eclipse.rap.rwt.testfixture/.classpath
+++ b/tests/org.eclipse.rap.rwt.testfixture/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.rwt.testfixture/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.testfixture/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.eclipse.rap.rwt.testfixture
 Bundle-Version: 4.6.0.qualifier
 Require-Bundle: org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)"
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.servlet;version="6.0.0",
  jakarta.servlet.descriptor;version="6.0.0",
  jakarta.servlet.http;version="6.0.0",

--- a/tests/org.eclipse.rap.rwt.themes.test/.classpath
+++ b/tests/org.eclipse.rap.rwt.themes.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/org.eclipse.rap.rwt.themes.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.rwt.themes.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.rwt.themes.test
 Bundle-Version: 4.6.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.rap.design.example;bundle-version="[4.6.0,5.0.0)",
  org.eclipse.rap.rwt;bundle-version="[4.6.0,5.0.0)"
 Bundle-Vendor: %Bundle-Vendor

--- a/tests/org.eclipse.rap.test.all/.classpath
+++ b/tests/org.eclipse.rap.test.all/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.rap.rwt.test"/>

--- a/tests/org.eclipse.rap.test.all/.settings/RAPAllTestSuite.launch
+++ b/tests/org.eclipse.rap.test.all/.settings/RAPAllTestSuite.launch
@@ -21,7 +21,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.rap.test.RAPAllTestSuite"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.rap.test.all"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DusePerformanceOptimizations=true -DsleepTime=20 -Xmx128m"/>

--- a/tests/org.eclipse.rap.test.all/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.test.all/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.rap.test.all
 Bundle-Version: 4.6.0.qualifier
 Export-Package: org.eclipse.rap.test;version="4.6.0"
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Import-Package: org.eclipse.rap.rwt.testfixture.internal;version="[4.6.0,5.0.0)",
  org.junit;version="4.8.2",

--- a/tests/org.eclipse.rap.ui.forms.test/.classpath
+++ b/tests/org.eclipse.rap.ui.forms.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.rap.ui.forms.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.rap.ui.forms.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.rap.ui.forms.test
 Bundle-Version: 4.6.0.qualifier
 Fragment-Host: org.eclipse.rap.ui.forms;bundle-version="[4.6.0,5.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.junit;bundle-version="4.8.2",
  net.bytebuddy.byte-buddy,


### PR DESCRIPTION
Update bundle execution environments, compilation profiles, classpaths and launch configurations to JavaSE-21.

This change is required due to upstream Eclipse Platform bundles now requiring Java 21.