### PR TITLE
fix(issue-379): Textarea caret placement with left-click stopped on working starting from Firefox >= 148

### DIFF
--- a/bundles/org.eclipse.rap.rwt/js/rwt/event/EventHandlerUtil.js
+++ b/bundles/org.eclipse.rap.rwt/js/rwt/event/EventHandlerUtil.js
@@ -47,7 +47,7 @@ rwt.event.EventHandlerUtil = {
           // is forbidden and causes an error.
         }
         // NOTE: See also Bug 321372
-        if( event.button === 0 && tagName != null && tagName != "INPUT" && tagName != "SELECT" ) {
+        if( event.button === 0 && tagName != null && tagName != "INPUT" && tagName != "SELECT" && tagName != "TEXTAREA" ) {
           event.preventDefault();
         }
       };


### PR DESCRIPTION
See issue 379 for a full example and explanationhttps://github.com/eclipse-rap/org.eclipse.rap/issues/379