### PR TITLE
Fixed conditions.

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/serverpush/ServerPushManager.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/rap/rwt/internal/serverpush/ServerPushManager.java
@@ -156,8 +156,8 @@ public final class ServerPushManager implements SerializableCompatibility {
   @SuppressWarnings( "unused" )
   private boolean canReleaseBlockedRequest( HttpServletResponse response, long requestStartTime ) {
     boolean result = false;
-    if( !mustBlockCallBackRequest( requestStartTime ) ) {
-      result = true;
+    if( mustBlockCallBackRequest( requestStartTime ) ) {
+      result = false;
     } else if( isSessionExpired( requestStartTime ) ) {
       result = true;
     } else if( !serverPushRequestTracker.isActive( Thread.currentThread() ) ) {


### PR DESCRIPTION
The issue is described in "ServerPushManager.mustBlockCallBackRequest always return false in a particular code path".
Because of Object.wait in a particular path, one of the condition always becomes false, and session validation checks are not executed. if statement is changed. Code is compiled. The test cases that I read in org.eclipse.rap\tests\org.eclipse.rap.rwt.test\src\org\eclipse\rap\rwt\internal\serverpush\ServerPushManager_Test.java have unit-tests for singular function. In my opinion, none of those test the path mentioned above. Please let me know if anything is needed from me.