### PR TITLE
Cache ToolItem bounds to improve rendering performance

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/ToolBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2021 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2026 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -248,6 +248,7 @@ public class ToolBar extends Composite {
     if( ( style & SWT.VERTICAL ) != 0 ) {
       for( int i = 0; i < itemHolder.size(); i++ ) {
         ToolItem item = itemHolder.getItem( i );
+        item.layoutCache.invalidateBounds();
         Rectangle itemBounds = item.getBounds();
         width = Math.max( width, itemBounds.width );
         if( i == itemHolder.size() - 1 ) {
@@ -257,6 +258,7 @@ public class ToolBar extends Composite {
     } else {
       for( int i = 0; i < itemHolder.size(); i++ ) {
         ToolItem item = itemHolder.getItem( i );
+        item.layoutCache.invalidateBounds();
         Rectangle itemBounds = item.getBounds();
         height = Math.max( height, itemBounds.height );
         if( i == itemHolder.size() - 1 ) {
@@ -386,6 +388,7 @@ public class ToolBar extends Composite {
   void layoutItems() {
     for( int i = 0; i < itemHolder.size(); i++ ) {
       ToolItem item = itemHolder.getItem( i );
+      item.layoutCache.invalidateBounds();
       Rectangle ibounds = item.getBounds();
       Rectangle bounds = getBounds();
       boolean hasEnoughWidth = ibounds.x + ibounds.width <= bounds.width;

--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/ToolItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2026 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.internal.SerializableCompatibility;
 import org.eclipse.swt.internal.widgets.IToolItemAdapter;
 import org.eclipse.swt.internal.widgets.MarkupValidator;
 import org.eclipse.swt.internal.widgets.toolbarkit.ToolBarThemeAdapter;
@@ -65,6 +66,7 @@ public class ToolItem extends Item {
   private Image disabledImage;
   private Image hotImage;
   private transient IToolItemAdapter toolItemAdapter;
+  LayoutCache layoutCache;
 
 
   /**
@@ -146,6 +148,7 @@ public class ToolItem extends Item {
     this.parent = parent;
     visible = true;
     computedWidth = true;
+    layoutCache = new LayoutCache();
     parent.createItem( this, index );
     computeInitialWidth();
   }
@@ -404,6 +407,9 @@ public class ToolItem extends Item {
     } else if( RWT.TOOLTIP_MARKUP_ENABLED.equals( key ) && isToolTipMarkupEnabledFor( this ) ) {
       return;
     }
+    if( RWT.CUSTOM_VARIANT.equals( key ) ) {
+      layoutCache.invalidateBounds();
+    }
     checkMarkupPrecondition( key, TOOLTIP, () -> toolTipText == null );
     super.setData( key, value );
   }
@@ -493,6 +499,13 @@ public class ToolItem extends Item {
    */
   public Rectangle getBounds() {
     checkWidget();
+    if( !layoutCache.hasBounds() ) {
+      layoutCache.bounds = calculateBounds();
+    }
+    return safeCopy( layoutCache.bounds );
+  }
+
+  private Rectangle calculateBounds() {
     Rectangle clientArea = parent.getClientArea();
     int left = clientArea.x;
     int top = clientArea.y;
@@ -529,56 +542,55 @@ public class ToolItem extends Item {
     return new Rectangle( left, top, width, height );
   }
 
-   // TODO [tb] : if needed, cache dimensions to optimize performance
-   private int getHeight() {
-     int height;
-     if(    ( parent.style & SWT.VERTICAL ) != 0
-         && ( style & SWT.SEPARATOR ) != 0
-         && getControl() == null )
-     {
-       height = getSeparatorWidth();
-     } else {
-       height = 0;
-       ToolItem[] siblings = getParent().getItems();
-       for( int i = 0; i < siblings.length; i++ ) {
-         height = Math.max(  height, siblings[ i ].getPreferredHeight() );
-       }
-     }
-     return height;
-   }
+  private int getHeight() {
+    int height;
+    if(    ( parent.style & SWT.VERTICAL ) != 0
+        && ( style & SWT.SEPARATOR ) != 0
+        && getControl() == null )
+    {
+      height = getSeparatorWidth();
+    } else {
+      height = 0;
+      ToolItem[] siblings = getParent().getItems();
+      for( int i = 0; i < siblings.length; i++ ) {
+        height = Math.max(  height, siblings[ i ].getPreferredHeight() );
+      }
+    }
+    return height;
+  }
 
-   /**
-    * Gets the width of the receiver.
-    *
-    * @return the width
-    *
-    * @exception SWTException <ul>
-    *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
-    *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that
-    *    created the receiver</li>
-    * </ul>
-    */
-   public int getWidth() {
-     checkWidget();
-     int result;
-     boolean isVertical = ( parent.style & SWT.VERTICAL ) != 0;
-     if( ( style & SWT.SEPARATOR ) != 0 && ( !isVertical || !computedWidth ) ) {
-       result = width;
-     } else {
-       if( isVertical ) {
-         result = 0;
-         ToolItem[] siblings = getParent().getItems();
-         for( int i = 0; i < siblings.length; i++ ) {
-           if( ( siblings[ i ].style & SWT.SEPARATOR ) == 0 ) {
-             result = Math.max(  result, siblings[ i ].getPreferredWidth() );
-           }
-         }
-       } else {
-         result = getPreferredWidth();
-       }
-     }
-     return result;
-   }
+  /**
+   * Gets the width of the receiver.
+   *
+   * @return the width
+   *
+   * @exception SWTException <ul>
+   *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+   *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that
+   *    created the receiver</li>
+   * </ul>
+   */
+  public int getWidth() {
+    checkWidget();
+    int result;
+    boolean isVertical = ( parent.style & SWT.VERTICAL ) != 0;
+    if( ( style & SWT.SEPARATOR ) != 0 && ( !isVertical || !computedWidth ) ) {
+      result = width;
+    } else {
+      if( isVertical ) {
+        result = 0;
+        ToolItem[] siblings = getParent().getItems();
+        for( int i = 0; i < siblings.length; i++ ) {
+          if( ( siblings[ i ].style & SWT.SEPARATOR ) == 0 ) {
+            result = Math.max(  result, siblings[ i ].getPreferredWidth() );
+          }
+        }
+      } else {
+        result = getPreferredWidth();
+      }
+    }
+    return result;
+  }
 
   int getPreferredHeight() {
     int result = 0;
@@ -855,6 +867,10 @@ public class ToolItem extends Item {
     return parent;
   }
 
+  private static Rectangle safeCopy( Rectangle rect ) {
+    return new Rectangle( rect.x, rect.y, rect.width, rect.height );
+  }
+
   private static int checkStyle( int style ) {
     return checkBits( style,
                       SWT.PUSH,
@@ -867,6 +883,20 @@ public class ToolItem extends Item {
 
   void setVisible( boolean visible ) {
     this.visible = visible;
+  }
+
+  static final class LayoutCache implements SerializableCompatibility {
+
+    Rectangle bounds;
+
+    public boolean hasBounds() {
+      return bounds != null;
+    }
+
+    public void invalidateBounds() {
+      bounds = null;
+    }
+
   }
 
 }

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/ToolBar_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/ToolBar_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2021 Innoopract Informationssysteme GmbH and others.
+ * Copyright (c) 2002, 2026 Innoopract Informationssysteme GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package org.eclipse.swt.widgets;
 import static org.eclipse.rap.rwt.testfixture.internal.SerializationTestUtil.serializeAndDeserialize;
 import static org.eclipse.rap.rwt.testfixture.internal.TestUtil.createImage;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,7 @@ import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.internal.widgets.toolbarkit.ToolBarLCA;
 import org.junit.Before;
 import org.junit.Rule;
@@ -212,6 +214,78 @@ public class ToolBar_Test {
   }
 
   @Test
+  public void testComputeSize_invalidatesItemBoundsInHorizontalToolBar() {
+    ToolItem item = new ToolItem( toolBar, SWT.PUSH );
+    Rectangle cachedBounds = getCachedBounds( item );
+
+    toolBar.computeSize( SWT.DEFAULT, SWT.DEFAULT );
+
+    assertNotSame( cachedBounds, item.layoutCache.bounds );
+  }
+
+  @Test
+  public void testComputeSize_invalidatesItemBoundsInVerticalToolBar() {
+    toolBar = new ToolBar( shell, SWT.VERTICAL );
+    ToolItem item = new ToolItem( toolBar, SWT.PUSH );
+    Rectangle cachedBounds = getCachedBounds( item );
+
+    toolBar.computeSize( SWT.DEFAULT, SWT.DEFAULT );
+
+    assertNotSame( cachedBounds, item.layoutCache.bounds );
+  }
+
+  @Test
+  public void testLayoutItems_invalidatesItemBounds() {
+    ToolItem item = new ToolItem( toolBar, SWT.PUSH );
+    Rectangle cachedBounds = getCachedBounds( item );
+
+    toolBar.layoutItems();
+
+    assertNotSame( cachedBounds, item.layoutCache.bounds );
+  }
+
+  @Test
+  public void testSetBounds_invalidatesItemBounds() {
+    ToolItem item = new ToolItem( toolBar, SWT.PUSH );
+    Rectangle cachedBounds = getCachedBounds( item );
+
+    toolBar.setBounds( 0, 0, 100, 100 );
+
+    assertNotSame( cachedBounds, item.layoutCache.bounds );
+  }
+
+  @Test
+  public void testSetFont_invalidatesItemBounds() {
+    ToolItem item = new ToolItem( toolBar, SWT.PUSH );
+    Rectangle cachedBounds = getCachedBounds( item );
+
+    toolBar.setFont( display.getSystemFont() );
+
+    assertNotSame( cachedBounds, item.layoutCache.bounds );
+  }
+
+  @Test
+  public void testCreateItem_invalidatesExistingItemBounds() {
+    ToolItem item = new ToolItem( toolBar, SWT.PUSH );
+    Rectangle cachedBounds = getCachedBounds( item );
+
+    new ToolItem( toolBar, SWT.PUSH );
+
+    assertNotSame( cachedBounds, item.layoutCache.bounds );
+  }
+
+  @Test
+  public void testDestroyItem_invalidatesRemainingItemBounds() {
+    ToolItem item = new ToolItem( toolBar, SWT.PUSH );
+    ToolItem itemToDestroy = new ToolItem( toolBar, SWT.PUSH );
+    Rectangle cachedBounds = getCachedBounds( item );
+
+    itemToDestroy.dispose();
+
+    assertNotSame( cachedBounds, item.layoutCache.bounds );
+  }
+
+  @Test
   public void testIsSerializable() throws Exception {
     new ToolItem( toolBar, SWT.PUSH );
 
@@ -224,6 +298,11 @@ public class ToolBar_Test {
   public void testGetAdapter_LCA() {
     assertTrue( toolBar.getAdapter( WidgetLCA.class ) instanceof ToolBarLCA );
     assertSame( toolBar.getAdapter( WidgetLCA.class ), toolBar.getAdapter( WidgetLCA.class ) );
+  }
+
+  private static Rectangle getCachedBounds( ToolItem item ) {
+    item.getBounds();
+    return item.layoutCache.bounds;
   }
 
 }

--- a/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/ToolItem_Test.java
+++ b/tests/org.eclipse.rap.rwt.test/src/org/eclipse/swt/widgets/ToolItem_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 EclipseSource and others.
+ * Copyright (c) 2009, 2026 EclipseSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,10 @@
  ******************************************************************************/
 package org.eclipse.swt.widgets;
 
+import static org.eclipse.rap.rwt.testfixture.internal.SerializationTestUtil.serializeAndDeserialize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -24,6 +26,7 @@ import org.eclipse.rap.rwt.testfixture.TestContext;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.internal.widgets.MarkupValidator;
 import org.eclipse.swt.internal.widgets.toolitemkit.ToolItemLCA;
 import org.junit.Before;
@@ -247,6 +250,98 @@ public class ToolItem_Test {
   }
 
   @Test
+  public void testGetBounds_cachesBoundsAndReturnsCopy() {
+    toolItem.layoutCache.invalidateBounds();
+    assertFalse( toolItem.layoutCache.hasBounds() );
+
+    Rectangle cachedBounds = getCachedBounds( toolItem );
+    Rectangle bounds = toolItem.getBounds();
+
+    assertTrue( toolItem.layoutCache.hasBounds() );
+    assertEquals( bounds, cachedBounds );
+    assertNotSame( bounds, cachedBounds );
+    assertEquals( bounds, toolItem.getBounds() );
+    assertNotSame( bounds, toolItem.getBounds() );
+  }
+
+  @Test
+  public void testGetBounds_returnedCopyCanBeModified() {
+    Rectangle bounds = toolItem.getBounds();
+    Rectangle expected = new Rectangle( bounds.x, bounds.y, bounds.width, bounds.height );
+
+    bounds.x++;
+    bounds.y++;
+    bounds.width++;
+    bounds.height++;
+
+    assertEquals( expected, toolItem.getBounds() );
+  }
+
+  @Test
+  public void testSetCustomVariant_invalidatesCachedBounds() {
+    getCachedBounds( toolItem );
+
+    toolItem.setData( RWT.CUSTOM_VARIANT, "variant" );
+
+    assertFalse( toolItem.layoutCache.hasBounds() );
+  }
+
+  @Test
+  public void testSetText_invalidatesCachedBounds() {
+    Rectangle cachedBounds = getCachedBounds( toolItem );
+
+    toolItem.setText( "text" );
+
+    assertNotSame( cachedBounds, toolItem.layoutCache.bounds );
+  }
+
+  @Test
+  public void testSetImage_invalidatesCachedBounds() {
+    Rectangle cachedBounds = getCachedBounds( toolItem );
+
+    toolItem.setImage( display.getSystemImage( SWT.ICON_INFORMATION ) );
+
+    assertNotSame( cachedBounds, toolItem.layoutCache.bounds );
+  }
+
+  @Test
+  public void testSetDisabledImage_invalidatesCachedBounds() {
+    Rectangle cachedBounds = getCachedBounds( toolItem );
+
+    toolItem.setDisabledImage( display.getSystemImage( SWT.ICON_INFORMATION ) );
+
+    assertNotSame( cachedBounds, toolItem.layoutCache.bounds );
+  }
+
+  @Test
+  public void testSetHotImage_invalidatesCachedBounds() {
+    Rectangle cachedBounds = getCachedBounds( toolItem );
+
+    toolItem.setHotImage( display.getSystemImage( SWT.ICON_INFORMATION ) );
+
+    assertNotSame( cachedBounds, toolItem.layoutCache.bounds );
+  }
+
+  @Test
+  public void testSetWidth_invalidatesCachedBounds() {
+    ToolItem separator = new ToolItem( toolbar, SWT.SEPARATOR );
+    Rectangle cachedBounds = getCachedBounds( separator );
+
+    separator.setWidth( 50 );
+
+    assertNotSame( cachedBounds, separator.layoutCache.bounds );
+  }
+
+  @Test
+  public void testLayoutCacheIsSerializable() throws Exception {
+    Rectangle bounds = toolItem.getBounds();
+
+    ToolBar deserializedToolBar = serializeAndDeserialize( toolbar );
+
+    assertEquals( bounds, deserializedToolBar.getItem( 0 ).getBounds() );
+  }
+
+  @Test
   public void testAddSelectionListener() {
     toolItem.addSelectionListener( mock( SelectionListener.class ) );
 
@@ -390,6 +485,11 @@ public class ToolItem_Test {
   public void testGetAdapter_LCA() {
     assertTrue( toolItem.getAdapter( WidgetLCA.class ) instanceof ToolItemLCA );
     assertSame( toolItem.getAdapter( WidgetLCA.class ), toolItem.getAdapter( WidgetLCA.class ) );
+  }
+
+  private static Rectangle getCachedBounds( ToolItem item ) {
+    item.getBounds();
+    return item.layoutCache.bounds;
   }
 
 }


### PR DESCRIPTION
ToolItem#getBounds recalculates layout on every call. ToolItemLCA queries these bounds while preserving and rendering items on every UI request, making repeated calculations costly for toolbars with many items.

Cache the computed bounds and invalidate them whenever the toolbar layout can change. Return defensive copies to protect the cached value, preserve it during serialization, and cover the caching and invalidation paths with tests.